### PR TITLE
Config files for ActiveMQ 5.8+

### DIFF
--- a/jmxtrans/json-detect-instance/activemq_v5.8_basic.json
+++ b/jmxtrans/json-detect-instance/activemq_v5.8_basic.json
@@ -17,7 +17,7 @@
                "obj": "org.apache.activemq:type=Broker,brokerName=localhost",
                "resultAlias": "sdamq.broker",
                "attr":[
-               	  "AverageMessageSize",
+                  "AverageMessageSize",
                   "CurrentConnectionsCount",
                   "JobSchedulerStoreLimit",
                   "JobSchedulerStorePercentUsage",

--- a/jmxtrans/json-detect-instance/activemq_v5.8_expanded.json
+++ b/jmxtrans/json-detect-instance/activemq_v5.8_expanded.json
@@ -17,7 +17,7 @@
                "obj": "org.apache.activemq:type=Broker,brokerName=localhost",
                "resultAlias": "sdamq.broker",
                "attr":[
-               	  "AverageMessageSize",
+                  "AverageMessageSize",
                   "CurrentConnectionsCount",
                   "JobSchedulerStoreLimit",
                   "JobSchedulerStorePercentUsage",

--- a/jmxtrans/json-specify-instance/activemq_v5.8_basic.json
+++ b/jmxtrans/json-specify-instance/activemq_v5.8_basic.json
@@ -17,7 +17,7 @@
                "obj": "org.apache.activemq:type=Broker,brokerName=localhost",
                "resultAlias": "sdamq.broker",
                "attr":[
-               	  "AverageMessageSize",
+                  "AverageMessageSize",
                   "CurrentConnectionsCount",
                   "JobSchedulerStoreLimit",
                   "JobSchedulerStorePercentUsage",

--- a/jmxtrans/json-specify-instance/activemq_v5.8_expanded.json
+++ b/jmxtrans/json-specify-instance/activemq_v5.8_expanded.json
@@ -17,7 +17,7 @@
                "obj": "org.apache.activemq:type=Broker,brokerName=localhost",
                "resultAlias": "sdamq.broker",
                "attr":[
-               	  "AverageMessageSize",
+                  "AverageMessageSize",
                   "CurrentConnectionsCount",
                   "JobSchedulerStoreLimit",
                   "JobSchedulerStorePercentUsage",


### PR DESCRIPTION
Adds support for ActiveMQ 5.8 and higher.  Earlier versions have different mBean structure, and could be adapted from these files.

There are two versions included here:
1. Basic monitoring -  These are server level metrics with the intent of having it supported as a "service" in Stackdriver with its own service page and named tab on the instance page.
2. Expanded monitoring - Includes the basic metrics and also some custom metrics for individual queues and topics that can be added to a custom dashboard for more detailed/targeted monitoring.  

The extended metrics are not included by default since they could be quite numerous on servers with a lot of configured destinations.  They could also be edited down to only the ones interesting to the user, or to queries for specific queue/topic names.

The typesNames elements in the JSON are inserted between the prefix and attribute names, so for a queue called "testqueue" you'd get the metricname "activemq.testqueue.QueueSize" for the QueueSize instance.
