### PR TITLE
add paths to gateway url overrides

### DIFF
--- a/jmxtrans/google-cloud-monitoring/json-detect-instance/activemq_v5.8_basic.json
+++ b/jmxtrans/google-cloud-monitoring/json-detect-instance/activemq_v5.8_basic.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }

--- a/jmxtrans/google-cloud-monitoring/json-detect-instance/activemq_v5.8_expanded.json
+++ b/jmxtrans/google-cloud-monitoring/json-detect-instance/activemq_v5.8_expanded.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -44,7 +44,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE",
                         "typeNames" : ["destinationName"]
                      }
@@ -67,7 +67,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE",
                         "typeNames" : ["destinationName"]
                      }

--- a/jmxtrans/google-cloud-monitoring/json-detect-instance/cassandra-06.json
+++ b/jmxtrans/google-cloud-monitoring/json-detect-instance/cassandra-06.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -28,7 +28,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -47,7 +47,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -65,7 +65,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -85,7 +85,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -105,7 +105,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -125,7 +125,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -145,7 +145,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -165,7 +165,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -185,7 +185,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -205,7 +205,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -225,7 +225,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -245,7 +245,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -265,7 +265,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -285,7 +285,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -305,7 +305,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -325,7 +325,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -345,7 +345,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }

--- a/jmxtrans/google-cloud-monitoring/json-detect-instance/cassandra.json
+++ b/jmxtrans/google-cloud-monitoring/json-detect-instance/cassandra.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -28,7 +28,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -47,7 +47,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -65,7 +65,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -85,7 +85,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -105,7 +105,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -125,7 +125,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -145,7 +145,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -165,7 +165,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -185,7 +185,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -205,7 +205,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -225,7 +225,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -245,7 +245,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -265,7 +265,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -285,7 +285,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -305,7 +305,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -325,7 +325,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -345,7 +345,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -365,7 +365,7 @@
                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                     "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                     }
                   }

--- a/jmxtrans/google-cloud-monitoring/json-detect-instance/custom.json
+++ b/jmxtrans/google-cloud-monitoring/json-detect-instance/custom.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -29,7 +29,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }

--- a/jmxtrans/google-cloud-monitoring/json-detect-instance/hbase_thrift.json
+++ b/jmxtrans/google-cloud-monitoring/json-detect-instance/hbase_thrift.json
@@ -10,7 +10,7 @@
         	  "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -25,7 +25,7 @@
            	  "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }

--- a/jmxtrans/google-cloud-monitoring/json-detect-instance/hbase_v0.95.json
+++ b/jmxtrans/google-cloud-monitoring/json-detect-instance/hbase_v0.95.json
@@ -10,7 +10,7 @@
         	"@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
                 "settings": {
                   "token": "STACKDRIVER_API_KEY",
-                  "url":"https://jmx-gateway.google.stackdriver.com",
+                  "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                   "detectInstance": "GCE"
                 }
               }

--- a/jmxtrans/google-cloud-monitoring/json-detect-instance/hbase_v0.98.json
+++ b/jmxtrans/google-cloud-monitoring/json-detect-instance/hbase_v0.98.json
@@ -10,7 +10,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -25,7 +25,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -40,7 +40,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }

--- a/jmxtrans/google-cloud-monitoring/json-detect-instance/jboss.json
+++ b/jmxtrans/google-cloud-monitoring/json-detect-instance/jboss.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE",
                         "typeNames" : [ "name" ]
                      }
@@ -26,7 +26,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE",
                         "typeNames" : [ "name" ]
                      }
@@ -42,7 +42,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE",
                         "typeNames" : [ "name" ]
                      }

--- a/jmxtrans/google-cloud-monitoring/json-detect-instance/jvm-sun-hotspot.json
+++ b/jmxtrans/google-cloud-monitoring/json-detect-instance/jvm-sun-hotspot.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -29,7 +29,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -47,7 +47,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -64,7 +64,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -86,7 +86,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }

--- a/jmxtrans/google-cloud-monitoring/json-detect-instance/kafka.json
+++ b/jmxtrans/google-cloud-monitoring/json-detect-instance/kafka.json
@@ -13,7 +13,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -28,7 +28,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -43,7 +43,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -58,7 +58,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -73,7 +73,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -88,7 +88,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -103,7 +103,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -118,7 +118,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -133,7 +133,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -148,7 +148,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -163,7 +163,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -178,7 +178,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -193,7 +193,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -208,7 +208,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -223,7 +223,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -238,7 +238,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -253,7 +253,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -268,7 +268,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -283,7 +283,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -298,7 +298,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -313,7 +313,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -328,7 +328,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -343,7 +343,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -358,7 +358,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -373,7 +373,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -388,7 +388,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -403,7 +403,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -418,7 +418,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -433,7 +433,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -448,7 +448,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -463,7 +463,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -478,7 +478,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }

--- a/jmxtrans/google-cloud-monitoring/json-detect-instance/tomcat-7.json
+++ b/jmxtrans/google-cloud-monitoring/json-detect-instance/tomcat-7.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -29,7 +29,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -46,7 +46,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }
@@ -67,7 +67,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "detectInstance": "GCE"
                      }
                   }

--- a/jmxtrans/google-cloud-monitoring/json-specify-instance/activemq_v5.8_basic.json
+++ b/jmxtrans/google-cloud-monitoring/json-specify-instance/activemq_v5.8_basic.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "INSTANCE_ID"
                      }
                   }

--- a/jmxtrans/google-cloud-monitoring/json-specify-instance/activemq_v5.8_expanded.json
+++ b/jmxtrans/google-cloud-monitoring/json-specify-instance/activemq_v5.8_expanded.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "INSTANCE_ID"
                      }
                   }
@@ -44,7 +44,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "INSTANCE_ID",
                         "typeNames" : ["destinationName"]
                      }
@@ -67,7 +67,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "INSTANCE_ID",
                         "typeNames" : ["destinationName"]
                      }

--- a/jmxtrans/google-cloud-monitoring/json-specify-instance/cassandra.json
+++ b/jmxtrans/google-cloud-monitoring/json-specify-instance/cassandra.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -28,7 +28,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -47,7 +47,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -65,7 +65,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -85,7 +85,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -105,7 +105,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -125,7 +125,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -145,7 +145,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -165,7 +165,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -185,7 +185,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -205,7 +205,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -225,7 +225,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -245,7 +245,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -265,7 +265,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -285,7 +285,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -305,7 +305,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -325,7 +325,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -345,7 +345,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -365,7 +365,7 @@
                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                     "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                     }
                   }

--- a/jmxtrans/google-cloud-monitoring/json-specify-instance/custom.json
+++ b/jmxtrans/google-cloud-monitoring/json-specify-instance/custom.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -29,7 +29,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }

--- a/jmxtrans/google-cloud-monitoring/json-specify-instance/hbase_thrift.json
+++ b/jmxtrans/google-cloud-monitoring/json-specify-instance/hbase_thrift.json
@@ -10,7 +10,7 @@
         	  "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -25,7 +25,7 @@
            	  "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }

--- a/jmxtrans/google-cloud-monitoring/json-specify-instance/hbase_v0.95.json
+++ b/jmxtrans/google-cloud-monitoring/json-specify-instance/hbase_v0.95.json
@@ -10,7 +10,7 @@
                 "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
                 "settings": {
                   "token": "STACKDRIVER_API_KEY",
-                  "url":"https://jmx-gateway.google.stackdriver.com",
+                  "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                   "source": "AWS_INSTANCE_ID"
                 }
               }

--- a/jmxtrans/google-cloud-monitoring/json-specify-instance/hbase_v0.98.json
+++ b/jmxtrans/google-cloud-monitoring/json-specify-instance/hbase_v0.98.json
@@ -10,7 +10,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -25,7 +25,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -40,7 +40,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }

--- a/jmxtrans/google-cloud-monitoring/json-specify-instance/jboss.json
+++ b/jmxtrans/google-cloud-monitoring/json-specify-instance/jboss.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID",
                         "typeNames" : [ "name" ]
                      }
@@ -26,7 +26,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID",
                         "typeNames" : [ "name" ]
                      }
@@ -42,7 +42,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID",
                         "typeNames" : [ "name" ]
                      }

--- a/jmxtrans/google-cloud-monitoring/json-specify-instance/jvm-sun-hotspot.json
+++ b/jmxtrans/google-cloud-monitoring/json-specify-instance/jvm-sun-hotspot.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -29,7 +29,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -47,7 +47,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -64,7 +64,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -86,7 +86,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }

--- a/jmxtrans/google-cloud-monitoring/json-specify-instance/kafka.json
+++ b/jmxtrans/google-cloud-monitoring/json-specify-instance/kafka.json
@@ -13,7 +13,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -28,7 +28,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -43,7 +43,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -58,7 +58,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -73,7 +73,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -88,7 +88,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -103,7 +103,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -118,7 +118,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -133,7 +133,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -148,7 +148,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -163,7 +163,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -178,7 +178,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -193,7 +193,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -208,7 +208,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -223,7 +223,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -238,7 +238,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -253,7 +253,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -268,7 +268,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -283,7 +283,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -298,7 +298,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -313,7 +313,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -328,7 +328,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -343,7 +343,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -358,7 +358,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -373,7 +373,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -388,7 +388,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -403,7 +403,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -418,7 +418,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -433,7 +433,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -448,7 +448,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -463,7 +463,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -478,7 +478,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com",
+                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }

--- a/jmxtrans/google-cloud-monitoring/json-specify-instance/tomcat-7.json
+++ b/jmxtrans/google-cloud-monitoring/json-specify-instance/tomcat-7.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -29,7 +29,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -46,7 +46,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -67,7 +67,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com",
+                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }

--- a/jmxtrans/stackdriver/json-detect-instance/activemq_v5.8_basic.json
+++ b/jmxtrans/stackdriver/json-detect-instance/activemq_v5.8_basic.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }

--- a/jmxtrans/stackdriver/json-detect-instance/activemq_v5.8_expanded.json
+++ b/jmxtrans/stackdriver/json-detect-instance/activemq_v5.8_expanded.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -44,7 +44,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS",
                         "typeNames" : ["destinationName"]
                      }
@@ -67,7 +67,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS",
                         "typeNames" : ["destinationName"]
                      }

--- a/jmxtrans/stackdriver/json-detect-instance/cassandra-06.json
+++ b/jmxtrans/stackdriver/json-detect-instance/cassandra-06.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -28,7 +28,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -47,7 +47,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -65,7 +65,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -85,7 +85,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -105,7 +105,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -125,7 +125,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -145,7 +145,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -165,7 +165,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -185,7 +185,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -205,7 +205,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -225,7 +225,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -245,7 +245,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -265,7 +265,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -285,7 +285,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -305,7 +305,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -325,7 +325,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -345,7 +345,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }

--- a/jmxtrans/stackdriver/json-detect-instance/cassandra.json
+++ b/jmxtrans/stackdriver/json-detect-instance/cassandra.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -28,7 +28,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -47,7 +47,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -65,7 +65,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -85,7 +85,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -105,7 +105,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -125,7 +125,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -145,7 +145,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -165,7 +165,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -185,7 +185,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -205,7 +205,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -225,7 +225,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -245,7 +245,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -265,7 +265,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -285,7 +285,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -305,7 +305,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -325,7 +325,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -345,7 +345,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -365,7 +365,7 @@
                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                     "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                     }
                   }

--- a/jmxtrans/stackdriver/json-detect-instance/custom.json
+++ b/jmxtrans/stackdriver/json-detect-instance/custom.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -29,7 +29,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }

--- a/jmxtrans/stackdriver/json-detect-instance/hbase_thrift.json
+++ b/jmxtrans/stackdriver/json-detect-instance/hbase_thrift.json
@@ -10,7 +10,7 @@
         	  "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -25,7 +25,7 @@
            	  "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }

--- a/jmxtrans/stackdriver/json-detect-instance/hbase_v0.95.json
+++ b/jmxtrans/stackdriver/json-detect-instance/hbase_v0.95.json
@@ -10,7 +10,7 @@
         	"@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
                 "settings": {
                   "token": "STACKDRIVER_API_KEY",
-                  "url":"https://jmx-gateway.stackdriver.com",
+                  "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                   "detectInstance": "AWS"
                 }
               }

--- a/jmxtrans/stackdriver/json-detect-instance/hbase_v0.98.json
+++ b/jmxtrans/stackdriver/json-detect-instance/hbase_v0.98.json
@@ -10,7 +10,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -25,7 +25,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -40,7 +40,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }

--- a/jmxtrans/stackdriver/json-detect-instance/jboss.json
+++ b/jmxtrans/stackdriver/json-detect-instance/jboss.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS",
                         "typeNames" : [ "name" ]
                      }
@@ -26,7 +26,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS",
                         "typeNames" : [ "name" ]
                      }
@@ -42,7 +42,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS",
                         "typeNames" : [ "name" ]
                      }

--- a/jmxtrans/stackdriver/json-detect-instance/jvm-sun-hotspot.json
+++ b/jmxtrans/stackdriver/json-detect-instance/jvm-sun-hotspot.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -29,7 +29,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -47,7 +47,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -64,7 +64,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -86,7 +86,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }

--- a/jmxtrans/stackdriver/json-detect-instance/kafka.json
+++ b/jmxtrans/stackdriver/json-detect-instance/kafka.json
@@ -13,7 +13,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -28,7 +28,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -43,7 +43,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -58,7 +58,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -73,7 +73,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -88,7 +88,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -103,7 +103,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -118,7 +118,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -133,7 +133,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -148,7 +148,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -163,7 +163,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -178,7 +178,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -193,7 +193,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -208,7 +208,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -223,7 +223,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -238,7 +238,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -253,7 +253,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -268,7 +268,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -283,7 +283,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -298,7 +298,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -313,7 +313,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -328,7 +328,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -343,7 +343,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -358,7 +358,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -373,7 +373,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -388,7 +388,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -403,7 +403,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -418,7 +418,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -433,7 +433,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -448,7 +448,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -463,7 +463,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -478,7 +478,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }

--- a/jmxtrans/stackdriver/json-detect-instance/tomcat-7.json
+++ b/jmxtrans/stackdriver/json-detect-instance/tomcat-7.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -29,7 +29,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -46,7 +46,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }
@@ -67,7 +67,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "detectInstance": "AWS"
                      }
                   }

--- a/jmxtrans/stackdriver/json-specify-instance/activemq_v5.8_basic.json
+++ b/jmxtrans/stackdriver/json-specify-instance/activemq_v5.8_basic.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "INSTANCE_ID"
                      }
                   }

--- a/jmxtrans/stackdriver/json-specify-instance/activemq_v5.8_expanded.json
+++ b/jmxtrans/stackdriver/json-specify-instance/activemq_v5.8_expanded.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "INSTANCE_ID"
                      }
                   }
@@ -44,7 +44,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "INSTANCE_ID",
                         "typeNames" : ["destinationName"]
                      }
@@ -67,7 +67,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "INSTANCE_ID",
                         "typeNames" : ["destinationName"]
                      }

--- a/jmxtrans/stackdriver/json-specify-instance/cassandra.json
+++ b/jmxtrans/stackdriver/json-specify-instance/cassandra.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -28,7 +28,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -47,7 +47,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -65,7 +65,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -85,7 +85,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -105,7 +105,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -125,7 +125,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -145,7 +145,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -165,7 +165,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -185,7 +185,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -205,7 +205,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -225,7 +225,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -245,7 +245,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -265,7 +265,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -285,7 +285,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -305,7 +305,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -325,7 +325,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -345,7 +345,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -365,7 +365,7 @@
                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                     "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                     }
                   }

--- a/jmxtrans/stackdriver/json-specify-instance/custom.json
+++ b/jmxtrans/stackdriver/json-specify-instance/custom.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -29,7 +29,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }

--- a/jmxtrans/stackdriver/json-specify-instance/hbase_thrift.json
+++ b/jmxtrans/stackdriver/json-specify-instance/hbase_thrift.json
@@ -10,7 +10,7 @@
         	  "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -25,7 +25,7 @@
            	  "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }

--- a/jmxtrans/stackdriver/json-specify-instance/hbase_v0.95.json
+++ b/jmxtrans/stackdriver/json-specify-instance/hbase_v0.95.json
@@ -10,7 +10,7 @@
                 "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
                 "settings": {
                   "token": "STACKDRIVER_API_KEY",
-                  "url":"https://jmx-gateway.stackdriver.com",
+                  "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                   "source": "AWS_INSTANCE_ID"
                 }
               }

--- a/jmxtrans/stackdriver/json-specify-instance/hbase_v0.98.json
+++ b/jmxtrans/stackdriver/json-specify-instance/hbase_v0.98.json
@@ -10,7 +10,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -25,7 +25,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -40,7 +40,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }

--- a/jmxtrans/stackdriver/json-specify-instance/jboss.json
+++ b/jmxtrans/stackdriver/json-specify-instance/jboss.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID",
                         "typeNames" : [ "name" ]
                      }
@@ -26,7 +26,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID",
                         "typeNames" : [ "name" ]
                      }
@@ -42,7 +42,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID",
                         "typeNames" : [ "name" ]
                      }

--- a/jmxtrans/stackdriver/json-specify-instance/jvm-sun-hotspot.json
+++ b/jmxtrans/stackdriver/json-specify-instance/jvm-sun-hotspot.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -29,7 +29,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -47,7 +47,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -64,7 +64,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -86,7 +86,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }

--- a/jmxtrans/stackdriver/json-specify-instance/kafka.json
+++ b/jmxtrans/stackdriver/json-specify-instance/kafka.json
@@ -13,7 +13,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -28,7 +28,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -43,7 +43,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -58,7 +58,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -73,7 +73,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -88,7 +88,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -103,7 +103,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -118,7 +118,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -133,7 +133,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -148,7 +148,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -163,7 +163,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -178,7 +178,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -193,7 +193,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -208,7 +208,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -223,7 +223,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -238,7 +238,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -253,7 +253,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -268,7 +268,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -283,7 +283,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -298,7 +298,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -313,7 +313,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -328,7 +328,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -343,7 +343,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -358,7 +358,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -373,7 +373,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -388,7 +388,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -403,7 +403,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -418,7 +418,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -433,7 +433,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -448,7 +448,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -463,7 +463,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -478,7 +478,7 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com",
+                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }

--- a/jmxtrans/stackdriver/json-specify-instance/tomcat-7.json
+++ b/jmxtrans/stackdriver/json-specify-instance/tomcat-7.json
@@ -10,7 +10,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -29,7 +29,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -46,7 +46,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }
@@ -67,7 +67,7 @@
                      "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
                      "settings":{
                         "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com",
+                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
                         "source": "AWS_INSTANCE_ID"
                      }
                   }


### PR DESCRIPTION
The default URL in the jmxtrans plugin POSTs to /v1/custom.  The URL overrides in these files had no path so they would POST to the root of the gateway, returning an HTTP 405.

This change adds the path to the override URLs to they post to the proper URL.