### PR TITLE
Autogenerate the various JMX json files.

### DIFF
--- a/jmxtrans/google-cloud-monitoring/json-detect-instance/README
+++ b/jmxtrans/google-cloud-monitoring/json-detect-instance/README
@@ -1,0 +1,4 @@
+The files in this directory are automatically generated and will be overwritten.
+If you want to change them, please see
+../../templates/generate-json-files-from-templates.py
+and the .json.tmpl files in that directory.

--- a/jmxtrans/google-cloud-monitoring/json-detect-instance/activemq_v5.8_basic.json
+++ b/jmxtrans/google-cloud-monitoring/json-detect-instance/activemq_v5.8_basic.json
@@ -1,45 +1,45 @@
 {
-   "servers":[
-      {
-         "host":"ACTIVEMQ_JMX_HOST",
-         "port":"ACTIVEMQ_JMX_PORT",
-         "queries":[
+  "servers": [
+    {
+      "host": "ACTIVEMQ_JMX_HOST",
+      "port": "ACTIVEMQ_JMX_PORT",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "org.apache.activemq:type=Broker,brokerName=localhost",
+          "attr": [
+            "AverageMessageSize",
+            "CurrentConnectionsCount",
+            "JobSchedulerStoreLimit",
+            "JobSchedulerStorePercentUsage",
+            "MaxMessageSize",
+            "MemoryLimit",
+            "MemoryPercentUsage",
+            "MinMessageSize",
+            "StoreLimit",
+            "StorePercentUsage",
+            "TempLimit",
+            "TempPercentUsage",
+            "TotalConnectionsCount",
+            "TotalConsumerCount",
+            "TotalDequeueCount",
+            "TotalEnqueueCount",
+            "TotalMessageCount",
+            "TotalProducerCount"
+          ],
+          "resultAlias": "sdamq.broker",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-               ],
-               "obj": "org.apache.activemq:type=Broker,brokerName=localhost",
-               "resultAlias": "sdamq.broker",
-               "attr":[
-                  "AverageMessageSize",
-                  "CurrentConnectionsCount",
-                  "JobSchedulerStoreLimit",
-                  "JobSchedulerStorePercentUsage",
-                  "MaxMessageSize",
-                  "MemoryLimit",
-                  "MemoryPercentUsage",
-                  "MinMessageSize",
-                  "StoreLimit",
-                  "StorePercentUsage",
-                  "TempLimit",
-                  "TempPercentUsage",
-                  "TotalConnectionsCount",
-                  "TotalConsumerCount",
-                  "TotalDequeueCount",
-                  "TotalEnqueueCount",
-                  "TotalMessageCount",
-                  "TotalProducerCount"
-               ]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
             }
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/google-cloud-monitoring/json-detect-instance/activemq_v5.8_expanded.json
+++ b/jmxtrans/google-cloud-monitoring/json-detect-instance/activemq_v5.8_expanded.json
@@ -1,93 +1,96 @@
 {
-   "servers":[
-      {
-         "host":"ACTIVEMQ_JMX_HOST",
-         "port":"ACTIVEMQ_JMX_PORT",
-         "queries":[
+  "servers": [
+    {
+      "host": "ACTIVEMQ_JMX_HOST",
+      "port": "ACTIVEMQ_JMX_PORT",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "org.apache.activemq:type=Broker,brokerName=localhost",
+          "attr": [
+            "AverageMessageSize",
+            "CurrentConnectionsCount",
+            "JobSchedulerStoreLimit",
+            "JobSchedulerStorePercentUsage",
+            "MaxMessageSize",
+            "MemoryLimit",
+            "MemoryPercentUsage",
+            "MinMessageSize",
+            "StoreLimit",
+            "StorePercentUsage",
+            "TempLimit",
+            "TempPercentUsage",
+            "TotalConnectionsCount",
+            "TotalConsumerCount",
+            "TotalDequeueCount",
+            "TotalEnqueueCount",
+            "TotalMessageCount",
+            "TotalProducerCount"
+          ],
+          "resultAlias": "sdamq.broker",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-               ],
-               "obj": "org.apache.activemq:type=Broker,brokerName=localhost",
-               "resultAlias": "sdamq.broker",
-               "attr":[
-                  "AverageMessageSize",
-                  "CurrentConnectionsCount",
-                  "JobSchedulerStoreLimit",
-                  "JobSchedulerStorePercentUsage",
-                  "MaxMessageSize",
-                  "MemoryLimit",
-                  "MemoryPercentUsage",
-                  "MinMessageSize",
-                  "StoreLimit",
-                  "StorePercentUsage",
-                  "TempLimit",
-                  "TempPercentUsage",
-                  "TotalConnectionsCount",
-                  "TotalConsumerCount",
-                  "TotalDequeueCount",
-                  "TotalEnqueueCount",
-                  "TotalMessageCount",
-                  "TotalProducerCount"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE",
-                        "typeNames" : ["destinationName"]
-                     }
-                  }
-               ],
-               "obj": "org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Topic,destinationName=*",
-               "resultAlias": "activemq.topic",
-               "attr":[
-                  "ConsumerCount",
-                  "ProducerCount",
-                  "EnqueueCount",
-                  "DequeueCount",
-                  "InFlightCount",
-                  "ExpiredCount"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE",
-                        "typeNames" : ["destinationName"]
-                     }
-                  }
-               ],
-               "obj": "org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Queue,destinationName=*",
-               "resultAlias": "activemq.queue",
-               "attr":[
-                  "ConsumerCount",
-                  "ProducerCount",
-                  "QueueSize",
-                  "EnqueueCount",
-                  "DequeueCount",
-                  "InFlightCount",
-                  "ExpiredCount"
-               ]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
             }
-
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        },
+        {
+          "obj": "org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Topic,destinationName=*",
+          "attr": [
+            "ConsumerCount",
+            "ProducerCount",
+            "EnqueueCount",
+            "DequeueCount",
+            "InFlightCount",
+            "ExpiredCount"
+          ],
+          "resultAlias": "activemq.topic",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE",
+                "typeNames": [
+                  "destinationName"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Queue,destinationName=*",
+          "attr": [
+            "ConsumerCount",
+            "ProducerCount",
+            "QueueSize",
+            "EnqueueCount",
+            "DequeueCount",
+            "InFlightCount",
+            "ExpiredCount"
+          ],
+          "resultAlias": "activemq.queue",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE",
+                "typeNames": [
+                  "destinationName"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/google-cloud-monitoring/json-detect-instance/cassandra-06.json
+++ b/jmxtrans/google-cloud-monitoring/json-detect-instance/cassandra-06.json
@@ -1,366 +1,366 @@
 {
-   "servers":[
-      {
-         "port":"7199",
-         "host":"localhost",
-         "queries":[
+  "servers": [
+    {
+      "port": "7199",
+      "host": "localhost",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "org.apache.cassandra.db:type=StorageService",
+          "attr": [
+            "Load",
+            "ExceptionCount"
+          ],
+          "resultAlias": "cassandra.storageservice",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-               ],
-               "obj": "org.apache.cassandra.db:type=StorageService",
-               "resultAlias": "cassandra.storageservice",
-               "attr":[
-               		"Load",
-               		"ExceptionCount"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-               ],
-               "obj": "org.apache.cassandra.db:type=Commitlog",
-               "resultAlias": "cassandra.commitlog",
-               "attr":[
-                        "CompletedTasks",
-                        "PendingTasks",
-                        "TotalCommitlogSize"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.db:type=CompactionManager",
-				"resultAlias": "cassandra.compactionmanager",
-				"attr": [
-                        "PendingTasks",
-                        "CompletedTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.concurrent:type=ROW-MUTATION-STAGE",
-				"resultAlias": "cassandra.stage.MutationStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.concurrent:type=CONSISTENCY-MANAGER",
-				"resultAlias": "cassandra.stage.ReadRepairStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.concurrent:type=ROW-READ-STAGE",
-				"resultAlias": "cassandra.stage.ReadStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.request:type=ReplicateOnWriteStage",
-				"resultAlias": "cassandra.stage.ReplicateOnWriteStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.concurrent:type=RESPONSE-STAGE",
-				"resultAlias": "cassandra.stage.RequestResponseStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=AntiEntropySessions",
-				"resultAlias": "cassandra.internal.AntiEntropySessions",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=AntiEntropyStage",
-				"resultAlias": "cassandra.internal.AntiEntropyStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=FlushWriter",
-				"resultAlias": "cassandra.internal.FlushWriter",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=GossipStage",
-				"resultAlias": "cassandra.internal.GossipStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=HintedHandoff",
-				"resultAlias": "cassandra.internal.HintedHandoff",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=InternalResponseStage",
-				"resultAlias": "cassandra.internal.InternalResponseStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=MemtablePostFlusher",
-				"resultAlias": "cassandra.internal.MemtablePostFlusher",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=MigrationStage",
-				"resultAlias": "cassandra.internal.MigrationStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=MiscStage",
-				"resultAlias": "cassandra.internal.MiscStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=StreamStage",
-				"resultAlias": "cassandra.internal.StreamStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
             }
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.db:type=Commitlog",
+          "attr": [
+            "CompletedTasks",
+            "PendingTasks",
+            "TotalCommitlogSize"
+          ],
+          "resultAlias": "cassandra.commitlog",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.db:type=CompactionManager",
+          "attr": [
+            "PendingTasks",
+            "CompletedTasks"
+          ],
+          "resultAlias": "cassandra.compactionmanager",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.concurrent:type=ROW-MUTATION-STAGE",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.stage.MutationStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.concurrent:type=CONSISTENCY-MANAGER",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.stage.ReadRepairStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.concurrent:type=ROW-READ-STAGE",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.stage.ReadStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.request:type=ReplicateOnWriteStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.stage.ReplicateOnWriteStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.concurrent:type=RESPONSE-STAGE",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.stage.RequestResponseStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=AntiEntropySessions",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.AntiEntropySessions",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=AntiEntropyStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.AntiEntropyStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=FlushWriter",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.FlushWriter",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=GossipStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.GossipStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=HintedHandoff",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.HintedHandoff",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=InternalResponseStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.InternalResponseStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=MemtablePostFlusher",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.MemtablePostFlusher",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=MigrationStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.MigrationStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=MiscStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.MiscStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=StreamStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.StreamStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/google-cloud-monitoring/json-detect-instance/custom.json
+++ b/jmxtrans/google-cloud-monitoring/json-detect-instance/custom.json
@@ -1,47 +1,47 @@
 {
-   "servers":[
-      {
-         "port":"JMX PORT",
-         "host":"localhost",
-         "queries":[
+  "servers": [
+    {
+      "port": "JMX PORT",
+      "host": "localhost",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "MBEAN PATH",
+          "attr": [
+            "MBEAN ATTRIBUTE 1",
+            "MBEAN ATTRIBUTE 2",
+            "MBEAN ATTRIBUTE 3"
+          ],
+          "resultAlias": "MYAPP.MYSUBYSTEM.PREFIX",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-               ],
-               "obj": "MBEAN PATH",
-               "resultAlias": "MYAPP.MYSUBYSTEM.PREFIX",
-               "attr":[
-               	  "MBEAN ATTRIBUTE 1",
-                  "MBEAN ATTRIBUTE 2",
-                  "MBEAN ATTRIBUTE 3"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-               ],
-               "obj": "MBEAN 2 PATH",
-               "resultAlias": "MYAPP.MYSUBYSTEM.PREFIX",
-               "attr":[
-               	  "MBEAN ATTRIBUTE"
-               ]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
             }
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        },
+        {
+          "obj": "MBEAN 2 PATH",
+          "attr": [
+            "MBEAN ATTRIBUTE"
+          ],
+          "resultAlias": "MYAPP.MYSUBYSTEM.PREFIX",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/google-cloud-monitoring/json-detect-instance/hbase_thrift.json
+++ b/jmxtrans/google-cloud-monitoring/json-detect-instance/hbase_thrift.json
@@ -1,41 +1,55 @@
 {
-  "servers" : [
+  "servers": [
     {
-      "port" : "HBASE_THRIFT_JMX_PORT",
-      "host" : "HBASE_THRIFT_JMX_HOST",
-      "queries" : [
+      "port": "HBASE_THRIFT_JMX_PORT",
+      "host": "HBASE_THRIFT_JMX_HOST",
+      "numQueryThreads": 2,
+      "queries": [
         {
-          "outputWriters" : [
+          "obj": "Hadoop:service=HBase,name=Thrift,sub=ThriftOne",
+          "attr": [
+            "callQueueLen",
+            "SlowThriftCall_mean",
+            "TimeInQueue_mean",
+            "ThriftCall_mean",
+            "BatchGet_mean",
+            "BatchMutate_mean"
+          ],
+          "resultAlias": "sdhbase.Thrift.ThriftOne",
+          "outputWriters": [
             {
-        	  "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
-          ],
-          "obj" : "Hadoop:service=HBase,name=Thrift,sub=ThriftOne",
-          "attr" : [ "callQueueLen", "SlowThriftCall_mean", "TimeInQueue_mean", "ThriftCall_mean", "BatchGet_mean", "BatchMutate_mean" ],
-          "resultAlias": "sdhbase.Thrift.ThriftOne"
+          ]
         },
         {
-          "outputWriters" : [
+          "obj": "Hadoop:service=HBase,name=Thrift,sub=ThriftTwo",
+          "attr": [
+            "callQueueLen",
+            "SlowThriftCall_mean",
+            "TimeInQueue_mean",
+            "ThriftCall_mean",
+            "BatchGet_mean",
+            "BatchMutate_mean"
+          ],
+          "resultAlias": "sdhbase.Thrift.ThriftTwo",
+          "outputWriters": [
             {
-           	  "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
-          ],
-          "obj" : "Hadoop:service=HBase,name=Thrift,sub=ThriftTwo",
-          "attr" : [ "callQueueLen", "SlowThriftCall_mean", "TimeInQueue_mean", "ThriftCall_mean", "BatchGet_mean", "BatchMutate_mean" ],
-          "resultAlias": "sdhbase.Thrift.ThriftTwo"
+          ]
         }
-      ],
-      "numQueryThreads" : 2
+      ]
     }
   ]
 }

--- a/jmxtrans/google-cloud-monitoring/json-detect-instance/hbase_v0.95.json
+++ b/jmxtrans/google-cloud-monitoring/json-detect-instance/hbase_v0.95.json
@@ -1,26 +1,53 @@
 {
-  "servers" : [
+  "servers": [
     {
-      "port" : "HBASE_JMX_PORT",
-      "host" : "HBASE_JMX_HOST",
-      "queries" : [
+      "port": "HBASE_JMX_PORT",
+      "host": "HBASE_JMX_HOST",
+      "numQueryThreads": 2,
+      "queries": [
         {
-          "outputWriters" : [
-            {
-        	"@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                "settings": {
-                  "token": "STACKDRIVER_API_KEY",
-                  "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                  "detectInstance": "GCE"
-                }
-              }
+          "obj": "hadoop:service=RegionServer,name=RegionServerStatistics",
+          "attr": [
+            "blockCacheExpressCachingRatio",
+            "blockCacheHitCachingRatio",
+            "callQueueLength",
+            "compactionQueueLength",
+            "compactionQueueSize",
+            "flushQueueSize",
+            "hdfsBlocksLocalityIndex",
+            "memstoreSizeMB",
+            "numberOfOnlineRegions",
+            "readRequestsCount",
+            "slowHLogAppendCount",
+            "usedHeapMB",
+            "writeRequestsCount",
+            "blockCacheCount",
+            "blockCacheEvictedCount",
+            "blockCacheFreeMB",
+            "blockCacheHitCount",
+            "blockCacheMissCount",
+            "blockCacheSizeMB",
+            "fsPreadLatencyNumOps",
+            "fsReadLatencyNumOps",
+            "fsWriteLatencyNumOps",
+            "NumberOfStores",
+            "NumberOfStorefiles",
+            "requestsPerSecond",
+            "storeFileIndexSizeMB"
           ],
-          "obj" : "hadoop:service=RegionServer,name=RegionServerStatistics",
-          "attr" : [ "blockCacheExpressCachingRatio", "blockCacheHitCachingRatio", "callQueueLength", "compactionQueueLength", "compactionQueueSize", "flushQueueSize", "hdfsBlocksLocalityIndex", "memstoreSizeMB", "numberOfOnlineRegions", "readRequestsCount", "slowHLogAppendCount", "usedHeapMB", "writeRequestsCount", "blockCacheCount", "blockCacheEvictedCount", "blockCacheFreeMB", "blockCacheHitCount", "blockCacheMissCount", "blockCacheSizeMB", "fsPreadLatencyNumOps", "fsReadLatencyNumOps", "fsWriteLatencyNumOps", "NumberOfStores", "NumberOfStorefiles", "requestsPerSecond", "storeFileIndexSizeMB" ],
-          "resultAlias": "sdhbase.RegionServer.RegionServerStatistics"
+          "resultAlias": "sdhbase.RegionServer.RegionServerStatistics",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
         }
-      ],
-      "numQueryThreads" : 2
+      ]
     }
   ]
 }

--- a/jmxtrans/google-cloud-monitoring/json-detect-instance/hbase_v0.98.json
+++ b/jmxtrans/google-cloud-monitoring/json-detect-instance/hbase_v0.98.json
@@ -1,56 +1,84 @@
 {
-  "servers" : [
+  "servers": [
     {
-      "port" : "HBASE_JMX_PORT",
-      "host" : "HBASE_JMX_HOST",
-      "queries" : [
+      "port": "HBASE_JMX_PORT",
+      "host": "HBASE_JMX_HOST",
+      "numQueryThreads": 3,
+      "queries": [
         {
-          "outputWriters" : [
+          "obj": "Hadoop:service=HBase,name=Master,sub=Server",
+          "attr": [
+            "averageLoad",
+            "numRegionServers",
+            "numDeadRegionServers"
+          ],
+          "resultAlias": "sdhbase.Master.Server",
+          "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
-          ],
-          "obj" : "Hadoop:service=HBase,name=Master,sub=Server",
-          "attr" : [ "averageLoad", "numRegionServers","numDeadRegionServers" ],
-          "resultAlias": "sdhbase.Master.Server"
+          ]
         },
         {
-          "outputWriters" : [
+          "obj": "Hadoop:service=HBase,name=IPC,sub=IPC",
+          "attr": [
+            "sentBytes",
+            "receivedBytes",
+            "queueSize",
+            "numOpenConnections"
+          ],
+          "resultAlias": "sdhbase.IPC.IPC",
+          "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
-          ],
-          "obj" : "Hadoop:service=HBase,name=IPC,sub=IPC",
-          "attr" : [ "sentBytes","receivedBytes","queueSize","numOpenConnections"  ],
-          "resultAlias": "sdhbase.IPC.IPC"
+          ]
         },
         {
-          "outputWriters" : [
+          "obj": "Hadoop:service=HBase,name=RegionServer,sub=Server",
+          "attr": [
+            "blockCacheCount",
+            "blockCacheEvictionCount",
+            "blockCacheFreeSize",
+            "blockCacheHitCount",
+            "blockCountHitPercent",
+            "blockCacheMissCount",
+            "blockCacheSize",
+            "compactionQueueLength",
+            "flushQueueLength",
+            "memStoreSize",
+            "storeCount",
+            "readRequestCount",
+            "storeFileIndexSize",
+            "writeRequestCount",
+            "totalRequestCount",
+            "slowAppendCount",
+            "slowPutCount",
+            "slowGetCount"
+          ],
+          "resultAlias": "sdhbase.RegionServer.RegionServerStatistics",
+          "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
-          ],
-          "obj" : "Hadoop:service=HBase,name=RegionServer,sub=Server",
-          "attr" : [ "blockCacheCount", "blockCacheEvictionCount", "blockCacheFreeSize", "blockCacheHitCount", "blockCountHitPercent", "blockCacheMissCount", "blockCacheSize", "compactionQueueLength", "flushQueueLength", "memStoreSize", "storeCount", "readRequestCount", "storeFileIndexSize", "writeRequestCount", "totalRequestCount", "slowAppendCount", "slowPutCount", "slowGetCount" ],
-          "resultAlias": "sdhbase.RegionServer.RegionServerStatistics"
+          ]
         }
-      ],
-      "numQueryThreads" : 3
+      ]
     }
   ]
 }

--- a/jmxtrans/google-cloud-monitoring/json-detect-instance/jboss.json
+++ b/jmxtrans/google-cloud-monitoring/json-detect-instance/jboss.json
@@ -1,59 +1,81 @@
 {
-   "servers":[
-      {
-         "port":"8004",
-         "host":"localhost",
-         "queries":[
+  "servers": [
+    {
+      "port": "8004",
+      "host": "localhost",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "jboss.web:type=ThreadPool,name=*",
+          "attr": [
+            "currentThreadCount",
+            "currentThreadsBusy"
+          ],
+          "resultAlias": "jboss.threads",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE",
-                        "typeNames" : [ "name" ]
-                     }
-                  }
-               ],
-                "obj" : "jboss.web:type=ThreadPool,name=*",
-      			"resultAlias": "jboss.threads",
-      			"attr" : [ "currentThreadCount", "currentThreadsBusy"]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE",
-                        "typeNames" : [ "name" ]
-                     }
-                  }
-               ],
-                "obj" : "jboss.web:type=GlobalRequestProcessor,name=*",
-      			"resultAlias": "jboss.requests",
-      			"attr" : [ "bytesReceived", "bytesSent", "errorCount", "maxTime", "processingTime", "requestCount"  ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE",
-                        "typeNames" : [ "name" ]
-                     }
-                  }
-               ],
-                "obj" : "jboss.jca:service=ManagedConnectionPool,name=*",
-      			"resultAlias": "jboss.datasources",
-      			"attr" : [ "ConnectionCount", "ConnectionCreatedCount", "InUseConnectionCount",	"MaxConnectionsInUseCount", "AvailableConnectionCount" ]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE",
+                "typeNames": [
+                  "name"
+                ]
+              }
             }
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        },
+        {
+          "obj": "jboss.web:type=GlobalRequestProcessor,name=*",
+          "attr": [
+            "bytesReceived",
+            "bytesSent",
+            "errorCount",
+            "maxTime",
+            "processingTime",
+            "requestCount"
+          ],
+          "resultAlias": "jboss.requests",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE",
+                "typeNames": [
+                  "name"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "obj": "jboss.jca:service=ManagedConnectionPool,name=*",
+          "attr": [
+            "ConnectionCount",
+            "ConnectionCreatedCount",
+            "InUseConnectionCount",
+            "MaxConnectionsInUseCount",
+            "AvailableConnectionCount"
+          ],
+          "resultAlias": "jboss.datasources",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE",
+                "typeNames": [
+                  "name"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/google-cloud-monitoring/json-detect-instance/jvm-sun-hotspot.json
+++ b/jmxtrans/google-cloud-monitoring/json-detect-instance/jvm-sun-hotspot.json
@@ -1,105 +1,105 @@
 {
-   "servers":[
-      {
-         "port":"JMX_PORT",
-         "host":"JMX_HOST",
-         "queries":[
+  "servers": [
+    {
+      "port": "JMX_PORT",
+      "host": "JMX_HOST",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "java.lang:type=Threading",
+          "attr": [
+            "DaemonThreadCount",
+            "ThreadCount",
+            "PeakThreadCount"
+          ],
+          "resultAlias": "jvm.localhost.Threading",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-               ],
-               "obj": "java.lang:type=Threading",
-               "resultAlias": "jvm.localhost.Threading",
-               "attr":[
-               	  "DaemonThreadCount",
-                  "ThreadCount",
-                  "PeakThreadCount"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-               ],
-               "obj": "java.lang:type=Memory",
-               "resultAlias": "jvm.localhost.Memory",
-               "attr":[
-                  "HeapMemoryUsage",
-                  "NonHeapMemoryUsage"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-               ],
-               "obj": "java.lang:type=Runtime",
-               "resultAlias": "jvm.localhost.Runtime",
-               "attr":[
-                  "Uptime"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-               ],
-               "obj": "java.lang:type=OperatingSystem",
-               "resultAlias": "jvm.localhost.os",
-               "attr":[
-	                "CommittedVirtualMemorySize",
-	                "FreePhysicalMemorySize",
-	                "FreeSwapSpaceSize",
-	                "OpenFileDescriptorCount",
-	                "ProcessCpuTime",
-	                "SystemLoadAverage"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-               ],
-               "obj": "java.lang:type=GarbageCollector,name=*",
-               "resultAlias": "jvm.localhost.gc",
-               "attr":[
-	                "CollectionCount",
-	                "CollectionTime"
-               ]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
             }
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        },
+        {
+          "obj": "java.lang:type=Memory",
+          "attr": [
+            "HeapMemoryUsage",
+            "NonHeapMemoryUsage"
+          ],
+          "resultAlias": "jvm.localhost.Memory",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "java.lang:type=Runtime",
+          "attr": [
+            "Uptime"
+          ],
+          "resultAlias": "jvm.localhost.Runtime",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "java.lang:type=OperatingSystem",
+          "attr": [
+            "CommittedVirtualMemorySize",
+            "FreePhysicalMemorySize",
+            "FreeSwapSpaceSize",
+            "OpenFileDescriptorCount",
+            "ProcessCpuTime",
+            "SystemLoadAverage"
+          ],
+          "resultAlias": "jvm.localhost.os",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "java.lang:type=GarbageCollector,name=*",
+          "attr": [
+            "CollectionCount",
+            "CollectionTime"
+          ],
+          "resultAlias": "jvm.localhost.gc",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/google-cloud-monitoring/json-detect-instance/kafka.json
+++ b/jmxtrans/google-cloud-monitoring/json-detect-instance/kafka.json
@@ -1,19 +1,21 @@
 {
-  "servers":[
+  "servers": [
     {
       "port": "KAFKA_JMX_PORT",
       "host": "KAFKA_JMX_HOST",
-      "queries":[
+      "queries": [
         {
           "obj": "\"kafka.log\":type=\"LogFlushStats\",name=\"LogFlushRateAndTimeMs\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.log.LogFlushStats.LogFlush",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -21,14 +23,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"BrokerTopicMetrics\",name=\"AllTopicsBytesInPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.BrokerTopicMetrics.AllTopicsBytesIn",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -36,14 +40,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"BrokerTopicMetrics\",name=\"AllTopicsFailedFetchRequestsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.BrokerTopicMetrics.AllTopicsFailedFetchRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -51,14 +57,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"BrokerTopicMetrics\",name=\"AllTopicsFailedProduceRequestsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.BrokerTopicMetrics.AllTopicsFailedProduceRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -66,14 +74,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"BrokerTopicMetrics\",name=\"AllTopicsMessagesInPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.BrokerTopicMetrics.AllTopicsMessagesIn",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -81,14 +91,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"BrokerTopicMetrics\",name=\"AllTopicsBytesOutPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.BrokerTopicMetrics.AllTopicsBytesOut",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -96,14 +108,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaManager\",name=\"UnderReplicatedPartitions\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ReplicaManager.UnderReplicatedPartitions",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -111,14 +125,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaManager\",name=\"PartitionCount\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ReplicaManager.PartitionCount",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -126,14 +142,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaManager\",name=\"LeaderCount\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ReplicaManager.LeaderCount",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -141,14 +159,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaManager\",name=\"ISRShrinksPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.ReplicaManager.ISRShrinks",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -156,14 +176,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaManager\",name=\"IsrExpandsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.ReplicaManager.ISRExpands",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -171,14 +193,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaFetcherManager\",name=\"Replica-MaxLag\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ReplicaFetcherManager.MaxLag",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -186,14 +210,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaFetcherManager\",name=\"Replica-MinFetchRate\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ReplicaFetcherManager.MinFetchRate",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -201,14 +227,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ProducerRequestPurgatory\",name=\"NumDelayedRequests\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ProducerRequestPurgatory.NumDelayedRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -216,14 +244,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ProducerRequestPurgatory\",name=\"PurgatorySize\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ProducerRequestPurgatory.PurgatorySize",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -231,14 +261,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"FetchRequestPurgatory\",name=\"NumDelayedRequests\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.FetchRequestPurgatory.NumDelayedRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -246,14 +278,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"FetchRequestPurgatory\",name=\"PurgatorySize\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.FetchRequestPurgatory.PurgatorySize",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -261,14 +295,16 @@
         },
         {
           "obj": "\"kafka.network\":type=\"RequestMetrics\",name=\"Produce-RequestsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.network.RequestMetrics.ProduceRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -276,14 +312,16 @@
         },
         {
           "obj": "\"kafka.network\":type=\"RequestMetrics\",name=\"Fetch-Follower-RequestsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.network.RequestMetrics.FetchFollowerRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -291,14 +329,16 @@
         },
         {
           "obj": "\"kafka.network\":type=\"RequestMetrics\",name=\"Fetch-Consumer-RequestsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.network.RequestMetrics.FetchConsumerRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -306,14 +346,16 @@
         },
         {
           "obj": "\"kafka.controller\":type=\"KafkaController\",name=\"ActiveControllerCount\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.controller.KafkaController.ActiveControllerCount",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -321,14 +363,16 @@
         },
         {
           "obj": "\"kafka.controller\":type=\"KafkaController\",name=\"OfflinePartitionsCount\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.controller.KafkaController.OfflinePartitionsCount",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -336,14 +380,16 @@
         },
         {
           "obj": "\"kafka.controller\":type=\"ControllerStats\",name=\"LeaderElectionRateAndTimeMs\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.controller.ControllerStats.LeaderElection",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -351,14 +397,16 @@
         },
         {
           "obj": "\"kafka.controller\":type=\"ControllerStats\",name=\"UncleanLeaderElectionsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.controller.ControllerStats.UncleanLeaderElection",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -366,14 +414,16 @@
         },
         {
           "obj": "\"kafka.consumer\":type=\"ConsumerFetcherManager\",name=\"*-MaxLag\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.consumer.ConsumerFetcherManager.MaxLag",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -381,14 +431,16 @@
         },
         {
           "obj": "\"kafka.consumer\":type=\"ConsumerFetcherManager\",name=\"*-MinFetchRate\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.consumer.ConsumerFetcherManager.MinFetchRate",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -396,14 +448,16 @@
         },
         {
           "obj": "\"kafka.producer\":type=\"ProducerRequestsMetrics\",name=\"-AllBrokersProducerRequestSize\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.producer.ProducerRequestsMetrics.AllBrokersProducerRequestSize",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -411,14 +465,16 @@
         },
         {
           "obj": "\"kafka.producer\":type=\"ProducerRequestsMetrics\",name=\"-AllBrokersProducerRequestRateAndTimeMs\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.producer.ProducerRequestsMetrics.AllBrokersProducerRequestRate",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -426,14 +482,16 @@
         },
         {
           "obj": "\"kafka.producer\":type=\"ProducerStats\",name=\"-FailedSendsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.producer.ProducerStats.FailedSendsPerSec",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -441,14 +499,16 @@
         },
         {
           "obj": "\"kafka.producer\":type=\"ProducerTopicMetrics\",name=\"-AllTopicsBytesPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.producer.ProducerTopicMetrics.AllTopicsBytes",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -456,14 +516,16 @@
         },
         {
           "obj": "\"kafka.producer\":type=\"ProducerTopicMetrics\",name=\"-AllTopicsDroppedMessagesPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.producer.ProducerTopicMetrics.AllTopicsDroppedMessages",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }
@@ -471,14 +533,16 @@
         },
         {
           "obj": "\"kafka.producer\":type=\"ProducerTopicMetrics\",name=\"-AllTopicsMessagesPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.producer.ProducerTopicMetrics.AllTopicsMessages",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
                 "detectInstance": "GCE"
               }
             }

--- a/jmxtrans/google-cloud-monitoring/json-detect-instance/tomcat-7.json
+++ b/jmxtrans/google-cloud-monitoring/json-detect-instance/tomcat-7.json
@@ -1,86 +1,86 @@
 {
-   "servers":[
-      {
-         "port":"TOMCAT_JMX_PORT",
-         "host":"TOMCAT_JMX_HOST",
-         "queries":[
+  "servers": [
+    {
+      "port": "TOMCAT_JMX_PORT",
+      "host": "TOMCAT_JMX_HOST",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "Catalina:type=ThreadPool,name=*",
+          "attr": [
+            "currentThreadCount",
+            "currentThreadsBusy",
+            ""
+          ],
+          "resultAlias": "tomcat.connectors",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-               ],
-                "obj": "Catalina:type=ThreadPool,name=*",
-            	"resultAlias": "tomcat.connectors",
-            	"attr": [
-                	"currentThreadCount",
-                	"currentThreadsBusy", 
-                	""
-            	]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-               ],
-                "obj": "Catalina:type=Manager,context=*,host=*",
-            	"resultAlias": "tomcat.manager",
-            	"attr": [
-                	"activeSessions"
-            	]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-               ],
-                "obj": "Catalina:type=GlobalRequestProcessor,name=*",
-            	"resultAlias": "tomcat.requestProcessor",
-            	"attr": [
-                	"bytesReceived",
-                	"bytesSent",
-                	"errorCount",
-                	"processingTime",
-                	"requestCount"
-            	]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "detectInstance": "GCE"
-                     }
-                  }
-               ],
-                "obj": "Catalina:type=DataSource,context=*,host=*,class=javax.sql.DataSource,name=*",
-            	"resultAlias": "tomcat.data-source",
-            	"attr": [
-                	"numActive",
-                	"numIdle"
-            	]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
             }
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        },
+        {
+          "obj": "Catalina:type=Manager,context=*,host=*",
+          "attr": [
+            "activeSessions"
+          ],
+          "resultAlias": "tomcat.manager",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "Catalina:type=GlobalRequestProcessor,name=*",
+          "attr": [
+            "bytesReceived",
+            "bytesSent",
+            "errorCount",
+            "processingTime",
+            "requestCount"
+          ],
+          "resultAlias": "tomcat.requestProcessor",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "Catalina:type=DataSource,context=*,host=*,class=javax.sql.DataSource,name=*",
+          "attr": [
+            "numActive",
+            "numIdle"
+          ],
+          "resultAlias": "tomcat.data-source",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "detectInstance": "GCE"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/google-cloud-monitoring/json-specify-instance/README
+++ b/jmxtrans/google-cloud-monitoring/json-specify-instance/README
@@ -1,0 +1,4 @@
+The files in this directory are automatically generated and will be overwritten.
+If you want to change them, please see
+../../templates/generate-json-files-from-templates.py
+and the .json.tmpl files in that directory.

--- a/jmxtrans/google-cloud-monitoring/json-specify-instance/activemq_v5.8_basic.json
+++ b/jmxtrans/google-cloud-monitoring/json-specify-instance/activemq_v5.8_basic.json
@@ -1,45 +1,45 @@
 {
-   "servers":[
-      {
-         "host":"ACTIVEMQ_JMX_HOST",
-         "port":"ACTIVEMQ_JMX_PORT",
-         "queries":[
+  "servers": [
+    {
+      "host": "ACTIVEMQ_JMX_HOST",
+      "port": "ACTIVEMQ_JMX_PORT",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "org.apache.activemq:type=Broker,brokerName=localhost",
+          "attr": [
+            "AverageMessageSize",
+            "CurrentConnectionsCount",
+            "JobSchedulerStoreLimit",
+            "JobSchedulerStorePercentUsage",
+            "MaxMessageSize",
+            "MemoryLimit",
+            "MemoryPercentUsage",
+            "MinMessageSize",
+            "StoreLimit",
+            "StorePercentUsage",
+            "TempLimit",
+            "TempPercentUsage",
+            "TotalConnectionsCount",
+            "TotalConsumerCount",
+            "TotalDequeueCount",
+            "TotalEnqueueCount",
+            "TotalMessageCount",
+            "TotalProducerCount"
+          ],
+          "resultAlias": "sdamq.broker",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "INSTANCE_ID"
-                     }
-                  }
-               ],
-               "obj": "org.apache.activemq:type=Broker,brokerName=localhost",
-               "resultAlias": "sdamq.broker",
-               "attr":[
-                  "AverageMessageSize",
-                  "CurrentConnectionsCount",
-                  "JobSchedulerStoreLimit",
-                  "JobSchedulerStorePercentUsage",
-                  "MaxMessageSize",
-                  "MemoryLimit",
-                  "MemoryPercentUsage",
-                  "MinMessageSize",
-                  "StoreLimit",
-                  "StorePercentUsage",
-                  "TempLimit",
-                  "TempPercentUsage",
-                  "TotalConnectionsCount",
-                  "TotalConsumerCount",
-                  "TotalDequeueCount",
-                  "TotalEnqueueCount",
-                  "TotalMessageCount",
-                  "TotalProducerCount"
-               ]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
             }
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/google-cloud-monitoring/json-specify-instance/activemq_v5.8_expanded.json
+++ b/jmxtrans/google-cloud-monitoring/json-specify-instance/activemq_v5.8_expanded.json
@@ -1,93 +1,96 @@
 {
-   "servers":[
-      {
-         "host":"ACTIVEMQ_JMX_HOST",
-         "port":"ACTIVEMQ_JMX_PORT",
-         "queries":[
+  "servers": [
+    {
+      "host": "ACTIVEMQ_JMX_HOST",
+      "port": "ACTIVEMQ_JMX_PORT",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "org.apache.activemq:type=Broker,brokerName=localhost",
+          "attr": [
+            "AverageMessageSize",
+            "CurrentConnectionsCount",
+            "JobSchedulerStoreLimit",
+            "JobSchedulerStorePercentUsage",
+            "MaxMessageSize",
+            "MemoryLimit",
+            "MemoryPercentUsage",
+            "MinMessageSize",
+            "StoreLimit",
+            "StorePercentUsage",
+            "TempLimit",
+            "TempPercentUsage",
+            "TotalConnectionsCount",
+            "TotalConsumerCount",
+            "TotalDequeueCount",
+            "TotalEnqueueCount",
+            "TotalMessageCount",
+            "TotalProducerCount"
+          ],
+          "resultAlias": "sdamq.broker",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "INSTANCE_ID"
-                     }
-                  }
-               ],
-               "obj": "org.apache.activemq:type=Broker,brokerName=localhost",
-               "resultAlias": "sdamq.broker",
-               "attr":[
-                  "AverageMessageSize",
-                  "CurrentConnectionsCount",
-                  "JobSchedulerStoreLimit",
-                  "JobSchedulerStorePercentUsage",
-                  "MaxMessageSize",
-                  "MemoryLimit",
-                  "MemoryPercentUsage",
-                  "MinMessageSize",
-                  "StoreLimit",
-                  "StorePercentUsage",
-                  "TempLimit",
-                  "TempPercentUsage",
-                  "TotalConnectionsCount",
-                  "TotalConsumerCount",
-                  "TotalDequeueCount",
-                  "TotalEnqueueCount",
-                  "TotalMessageCount",
-                  "TotalProducerCount"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "INSTANCE_ID",
-                        "typeNames" : ["destinationName"]
-                     }
-                  }
-               ],
-               "obj": "org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Topic,destinationName=*",
-               "resultAlias": "activemq.topic",
-               "attr":[
-                  "ConsumerCount",
-                  "ProducerCount",
-                  "EnqueueCount",
-                  "DequeueCount",
-                  "InFlightCount",
-                  "ExpiredCount"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "INSTANCE_ID",
-                        "typeNames" : ["destinationName"]
-                     }
-                  }
-               ],
-               "obj": "org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Queue,destinationName=*",
-               "resultAlias": "activemq.queue",
-               "attr":[
-                  "ConsumerCount",
-                  "ProducerCount",
-                  "QueueSize",
-                  "EnqueueCount",
-                  "DequeueCount",
-                  "InFlightCount",
-                  "ExpiredCount"
-               ]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
             }
-
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        },
+        {
+          "obj": "org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Topic,destinationName=*",
+          "attr": [
+            "ConsumerCount",
+            "ProducerCount",
+            "EnqueueCount",
+            "DequeueCount",
+            "InFlightCount",
+            "ExpiredCount"
+          ],
+          "resultAlias": "activemq.topic",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID",
+                "typeNames": [
+                  "destinationName"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Queue,destinationName=*",
+          "attr": [
+            "ConsumerCount",
+            "ProducerCount",
+            "QueueSize",
+            "EnqueueCount",
+            "DequeueCount",
+            "InFlightCount",
+            "ExpiredCount"
+          ],
+          "resultAlias": "activemq.queue",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID",
+                "typeNames": [
+                  "destinationName"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/google-cloud-monitoring/json-specify-instance/cassandra-06.json
+++ b/jmxtrans/google-cloud-monitoring/json-specify-instance/cassandra-06.json
@@ -1,8 +1,8 @@
 {
   "servers": [
     {
-      "port": "CASSANDRA_PORT",
-      "host": "CASSANDRA_HOST",
+      "port": "7199",
+      "host": "localhost",
       "numQueryThreads": 2,
       "queries": [
         {
@@ -18,7 +18,7 @@
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
                 "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
@@ -37,7 +37,7 @@
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
                 "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
@@ -55,13 +55,13 @@
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
                 "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
-          "obj": "org.apache.cassandra.request:type=MutationStage",
+          "obj": "org.apache.cassandra.concurrent:type=ROW-MUTATION-STAGE",
           "attr": [
             "ActiveCount",
             "CompletedTasks",
@@ -75,13 +75,13 @@
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
                 "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
-          "obj": "org.apache.cassandra.request:type=ReadRepairStage",
+          "obj": "org.apache.cassandra.concurrent:type=CONSISTENCY-MANAGER",
           "attr": [
             "ActiveCount",
             "CompletedTasks",
@@ -95,13 +95,13 @@
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
                 "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
-          "obj": "org.apache.cassandra.request:type=ReadStage",
+          "obj": "org.apache.cassandra.concurrent:type=ROW-READ-STAGE",
           "attr": [
             "ActiveCount",
             "CompletedTasks",
@@ -115,7 +115,7 @@
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
                 "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
@@ -135,13 +135,13 @@
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
                 "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
-          "obj": "org.apache.cassandra.request:type=RequestResponseStage",
+          "obj": "org.apache.cassandra.concurrent:type=RESPONSE-STAGE",
           "attr": [
             "ActiveCount",
             "CompletedTasks",
@@ -155,7 +155,7 @@
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
                 "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
@@ -175,7 +175,7 @@
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
                 "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
@@ -195,7 +195,7 @@
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
                 "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
@@ -215,7 +215,7 @@
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
                 "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
@@ -235,7 +235,7 @@
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
                 "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
@@ -255,7 +255,7 @@
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
                 "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
@@ -275,7 +275,7 @@
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
                 "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
@@ -295,7 +295,7 @@
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
                 "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
@@ -315,7 +315,7 @@
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
                 "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
@@ -335,7 +335,7 @@
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
                 "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
@@ -355,27 +355,7 @@
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
                 "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
-              }
-            }
-          ]
-        },
-        {
-          "obj": "org.apache.cassandra.db:type=StorageProxy",
-          "attr": [
-            "RecentReadLatencyMicros",
-            "RecentWriteLatencyMicros",
-            "RecentRangeLatencyMicros",
-            "HintsInProgress"
-          ],
-          "resultAlias": "cassandra.internal.StorageProxy",
-          "outputWriters": [
-            {
-              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
-              "settings": {
-                "token": "STACKDRIVER_API_KEY",
-                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]

--- a/jmxtrans/google-cloud-monitoring/json-specify-instance/cassandra.json
+++ b/jmxtrans/google-cloud-monitoring/json-specify-instance/cassandra.json
@@ -1,386 +1,386 @@
 {
-   "servers":[
-      {
-         "port":"CASSANDRA_PORT",
-         "host":"CASSANDRA_HOST",
-         "queries":[
+  "servers": [
+    {
+      "port": "CASSANDRA_PORT",
+      "host": "CASSANDRA_HOST",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "org.apache.cassandra.db:type=StorageService",
+          "attr": [
+            "Load",
+            "ExceptionCount"
+          ],
+          "resultAlias": "cassandra.storageservice",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-               "obj": "org.apache.cassandra.db:type=StorageService",
-               "resultAlias": "cassandra.storageservice",
-               "attr":[
-               		"Load",
-               		"ExceptionCount"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-               "obj": "org.apache.cassandra.db:type=Commitlog",
-               "resultAlias": "cassandra.commitlog",
-               "attr":[
-			   	  "CompletedTasks",
-			      "PendingTasks",
-				  "TotalCommitlogSize"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.db:type=CompactionManager",
-				"resultAlias": "cassandra.compactionmanager",
-				"attr": [
-                        "PendingTasks",
-                        "CompletedTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.request:type=MutationStage",
-				"resultAlias": "cassandra.stage.MutationStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.request:type=ReadRepairStage",
-				"resultAlias": "cassandra.stage.ReadRepairStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.request:type=ReadStage",
-				"resultAlias": "cassandra.stage.ReadStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.request:type=ReplicateOnWriteStage",
-				"resultAlias": "cassandra.stage.ReplicateOnWriteStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.request:type=RequestResponseStage",
-				"resultAlias": "cassandra.stage.RequestResponseStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=AntiEntropySessions",
-				"resultAlias": "cassandra.internal.AntiEntropySessions",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=AntiEntropyStage",
-				"resultAlias": "cassandra.internal.AntiEntropyStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=FlushWriter",
-				"resultAlias": "cassandra.internal.FlushWriter",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=GossipStage",
-				"resultAlias": "cassandra.internal.GossipStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=HintedHandoff",
-				"resultAlias": "cassandra.internal.HintedHandoff",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=InternalResponseStage",
-				"resultAlias": "cassandra.internal.InternalResponseStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=MemtablePostFlusher",
-				"resultAlias": "cassandra.internal.MemtablePostFlusher",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=MigrationStage",
-				"resultAlias": "cassandra.internal.MigrationStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=MiscStage",
-				"resultAlias": "cassandra.internal.MiscStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=StreamStage",
-				"resultAlias": "cassandra.internal.StreamStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-              "outputWriters":[
-                  {
-                    "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                    "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                    }
-                  }
-				],
-                "obj": "org.apache.cassandra.db:type=StorageProxy",
-                "resultAlias": "cassandra.internal.StorageProxy",
-                "attr": [
-                        "RecentReadLatencyMicros",
-                        "RecentWriteLatencyMicros",
-                        "RecentRangeLatencyMicros",
-                        "HintsInProgress"
-                ]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
             }
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.db:type=Commitlog",
+          "attr": [
+            "CompletedTasks",
+            "PendingTasks",
+            "TotalCommitlogSize"
+          ],
+          "resultAlias": "cassandra.commitlog",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.db:type=CompactionManager",
+          "attr": [
+            "PendingTasks",
+            "CompletedTasks"
+          ],
+          "resultAlias": "cassandra.compactionmanager",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.request:type=MutationStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.stage.MutationStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.request:type=ReadRepairStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.stage.ReadRepairStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.request:type=ReadStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.stage.ReadStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.request:type=ReplicateOnWriteStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.stage.ReplicateOnWriteStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.request:type=RequestResponseStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.stage.RequestResponseStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=AntiEntropySessions",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.AntiEntropySessions",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=AntiEntropyStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.AntiEntropyStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=FlushWriter",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.FlushWriter",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=GossipStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.GossipStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=HintedHandoff",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.HintedHandoff",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=InternalResponseStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.InternalResponseStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=MemtablePostFlusher",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.MemtablePostFlusher",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=MigrationStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.MigrationStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=MiscStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.MiscStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=StreamStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.StreamStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.db:type=StorageProxy",
+          "attr": [
+            "RecentReadLatencyMicros",
+            "RecentWriteLatencyMicros",
+            "RecentRangeLatencyMicros",
+            "HintsInProgress"
+          ],
+          "resultAlias": "cassandra.internal.StorageProxy",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/google-cloud-monitoring/json-specify-instance/custom.json
+++ b/jmxtrans/google-cloud-monitoring/json-specify-instance/custom.json
@@ -1,47 +1,47 @@
 {
-   "servers":[
-      {
-         "port":"JMX PORT",
-         "host":"localhost",
-         "queries":[
+  "servers": [
+    {
+      "port": "JMX PORT",
+      "host": "localhost",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "MBEAN PATH",
+          "attr": [
+            "MBEAN ATTRIBUTE 1",
+            "MBEAN ATTRIBUTE 2",
+            "MBEAN ATTRIBUTE 3"
+          ],
+          "resultAlias": "MYAPP.MYSUBYSTEM.PREFIX",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-               "obj": "MBEAN PATH",
-               "resultAlias": "MYAPP.MYSUBYSTEM.PREFIX",
-               "attr":[
-               	  "MBEAN ATTRIBUTE 1",
-                  "MBEAN ATTRIBUTE 2",
-                  "MBEAN ATTRIBUTE 3"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-               "obj": "MBEAN 2 PATH",
-               "resultAlias": "MYAPP.MYSUBYSTEM.PREFIX",
-               "attr":[
-               	  "MBEAN ATTRIBUTE"
-               ]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
             }
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        },
+        {
+          "obj": "MBEAN 2 PATH",
+          "attr": [
+            "MBEAN ATTRIBUTE"
+          ],
+          "resultAlias": "MYAPP.MYSUBYSTEM.PREFIX",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/google-cloud-monitoring/json-specify-instance/hbase_thrift.json
+++ b/jmxtrans/google-cloud-monitoring/json-specify-instance/hbase_thrift.json
@@ -1,41 +1,55 @@
 {
-  "servers" : [
+  "servers": [
     {
-      "port" : "HBASE_THRIFT_JMX_PORT",
-      "host" : "HBASE_THRIFT_JMX_HOST",
-      "queries" : [
+      "port": "HBASE_THRIFT_JMX_PORT",
+      "host": "HBASE_THRIFT_JMX_HOST",
+      "numQueryThreads": 2,
+      "queries": [
         {
-          "outputWriters" : [
+          "obj": "Hadoop:service=HBase,name=Thrift,sub=ThriftOne",
+          "attr": [
+            "callQueueLen",
+            "SlowThriftCall_mean",
+            "TimeInQueue_mean",
+            "ThriftCall_mean",
+            "BatchGet_mean",
+            "BatchMutate_mean"
+          ],
+          "resultAlias": "sdhbase.Thrift.ThriftOne",
+          "outputWriters": [
             {
-        	  "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
-          ],
-          "obj" : "Hadoop:service=HBase,name=Thrift,sub=ThriftOne",
-          "attr" : [ "callQueueLen", "SlowThriftCall_mean", "TimeInQueue_mean", "ThriftCall_mean", "BatchGet_mean", "BatchMutate_mean" ],
-          "resultAlias": "sdhbase.Thrift.ThriftOne"
+          ]
         },
         {
-          "outputWriters" : [
+          "obj": "Hadoop:service=HBase,name=Thrift,sub=ThriftTwo",
+          "attr": [
+            "callQueueLen",
+            "SlowThriftCall_mean",
+            "TimeInQueue_mean",
+            "ThriftCall_mean",
+            "BatchGet_mean",
+            "BatchMutate_mean"
+          ],
+          "resultAlias": "sdhbase.Thrift.ThriftTwo",
+          "outputWriters": [
             {
-           	  "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
-          ],
-          "obj" : "Hadoop:service=HBase,name=Thrift,sub=ThriftTwo",
-          "attr" : [ "callQueueLen", "SlowThriftCall_mean", "TimeInQueue_mean", "ThriftCall_mean", "BatchGet_mean", "BatchMutate_mean" ],
-          "resultAlias": "sdhbase.Thrift.ThriftTwo"
+          ]
         }
-      ],
-      "numQueryThreads" : 2
+      ]
     }
   ]
 }

--- a/jmxtrans/google-cloud-monitoring/json-specify-instance/hbase_v0.95.json
+++ b/jmxtrans/google-cloud-monitoring/json-specify-instance/hbase_v0.95.json
@@ -1,26 +1,53 @@
 {
-  "servers" : [
+  "servers": [
     {
-      "port" : "HBASE_JMX_PORT",
-      "host" : "HBASE_JMX_HOST",
-      "queries" : [
+      "port": "HBASE_JMX_PORT",
+      "host": "HBASE_JMX_HOST",
+      "numQueryThreads": 2,
+      "queries": [
         {
-          "outputWriters" : [
-            {
-                "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                "settings": {
-                  "token": "STACKDRIVER_API_KEY",
-                  "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                  "source": "AWS_INSTANCE_ID"
-                }
-              }
+          "obj": "hadoop:service=RegionServer,name=RegionServerStatistics",
+          "attr": [
+            "blockCacheExpressCachingRatio",
+            "blockCacheHitCachingRatio",
+            "callQueueLength",
+            "compactionQueueLength",
+            "compactionQueueSize",
+            "flushQueueSize",
+            "hdfsBlocksLocalityIndex",
+            "memstoreSizeMB",
+            "numberOfOnlineRegions",
+            "readRequestsCount",
+            "slowHLogAppendCount",
+            "usedHeapMB",
+            "writeRequestsCount",
+            "blockCacheCount",
+            "blockCacheEvictedCount",
+            "blockCacheFreeMB",
+            "blockCacheHitCount",
+            "blockCacheMissCount",
+            "blockCacheSizeMB",
+            "fsPreadLatencyNumOps",
+            "fsReadLatencyNumOps",
+            "fsWriteLatencyNumOps",
+            "NumberOfStores",
+            "NumberOfStorefiles",
+            "requestsPerSecond",
+            "storeFileIndexSizeMB"
           ],
-          "obj" : "hadoop:service=RegionServer,name=RegionServerStatistics",
-          "attr" : [ "blockCacheExpressCachingRatio", "blockCacheHitCachingRatio", "callQueueLength", "compactionQueueLength", "compactionQueueSize", "flushQueueSize", "hdfsBlocksLocalityIndex", "memstoreSizeMB", "numberOfOnlineRegions", "readRequestsCount", "slowHLogAppendCount", "usedHeapMB", "writeRequestsCount", "blockCacheCount", "blockCacheEvictedCount", "blockCacheFreeMB", "blockCacheHitCount", "blockCacheMissCount", "blockCacheSizeMB", "fsPreadLatencyNumOps", "fsReadLatencyNumOps", "fsWriteLatencyNumOps", "NumberOfStores", "NumberOfStorefiles", "requestsPerSecond", "storeFileIndexSizeMB" ],
-          "resultAlias": "sdhbase.RegionServer.RegionServerStatistics"
+          "resultAlias": "sdhbase.RegionServer.RegionServerStatistics",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
         }
-      ],
-      "numQueryThreads" : 2
+      ]
     }
   ]
 }

--- a/jmxtrans/google-cloud-monitoring/json-specify-instance/hbase_v0.98.json
+++ b/jmxtrans/google-cloud-monitoring/json-specify-instance/hbase_v0.98.json
@@ -1,56 +1,84 @@
 {
-  "servers" : [
+  "servers": [
     {
-      "port" : "HBASE_JMX_PORT",
-      "host" : "HBASE_JMX_HOST",
-      "queries" : [
+      "port": "HBASE_JMX_PORT",
+      "host": "HBASE_JMX_HOST",
+      "numQueryThreads": 3,
+      "queries": [
         {
-          "outputWriters" : [
+          "obj": "Hadoop:service=HBase,name=Master,sub=Server",
+          "attr": [
+            "averageLoad",
+            "numRegionServers",
+            "numDeadRegionServers"
+          ],
+          "resultAlias": "sdhbase.Master.Server",
+          "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
-          ],
-          "obj" : "Hadoop:service=HBase,name=Master,sub=Server",
-          "attr" : [ "averageLoad", "numRegionServers","numDeadRegionServers" ],
-          "resultAlias": "sdhbase.Master.Server"
+          ]
         },
         {
-          "outputWriters" : [
+          "obj": "Hadoop:service=HBase,name=IPC,sub=IPC",
+          "attr": [
+            "sentBytes",
+            "receivedBytes",
+            "queueSize",
+            "numOpenConnections"
+          ],
+          "resultAlias": "sdhbase.IPC.IPC",
+          "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
-          ],
-          "obj" : "Hadoop:service=HBase,name=IPC,sub=IPC",
-          "attr" : [ "sentBytes","receivedBytes","queueSize","numOpenConnections"  ],
-          "resultAlias": "sdhbase.IPC.IPC"
+          ]
         },
         {
-          "outputWriters" : [
+          "obj": "Hadoop:service=HBase,name=RegionServer,sub=Server",
+          "attr": [
+            "blockCacheCount",
+            "blockCacheEvictionCount",
+            "blockCacheFreeSize",
+            "blockCacheHitCount",
+            "blockCountHitPercent",
+            "blockCacheMissCount",
+            "blockCacheSize",
+            "compactionQueueLength",
+            "flushQueueLength",
+            "memStoreSize",
+            "storeCount",
+            "readRequestCount",
+            "storeFileIndexSize",
+            "writeRequestCount",
+            "totalRequestCount",
+            "slowAppendCount",
+            "slowPutCount",
+            "slowGetCount"
+          ],
+          "resultAlias": "sdhbase.RegionServer.RegionServerStatistics",
+          "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
-          ],
-          "obj" : "Hadoop:service=HBase,name=RegionServer,sub=Server",
-          "attr" : [ "blockCacheCount", "blockCacheEvictionCount", "blockCacheFreeSize", "blockCacheHitCount", "blockCountHitPercent", "blockCacheMissCount", "blockCacheSize", "compactionQueueLength", "flushQueueLength", "memStoreSize", "storeCount", "readRequestCount", "storeFileIndexSize", "writeRequestCount", "totalRequestCount", "slowAppendCount", "slowPutCount", "slowGetCount" ],
-          "resultAlias": "sdhbase.RegionServer.RegionServerStatistics"
+          ]
         }
-      ],
-      "numQueryThreads" : 3
+      ]
     }
   ]
 }

--- a/jmxtrans/google-cloud-monitoring/json-specify-instance/jboss.json
+++ b/jmxtrans/google-cloud-monitoring/json-specify-instance/jboss.json
@@ -1,59 +1,81 @@
 {
-   "servers":[
-      {
-         "port":"8004",
-         "host":"localhost",
-         "queries":[
+  "servers": [
+    {
+      "port": "8004",
+      "host": "localhost",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "jboss.web:type=ThreadPool,name=*",
+          "attr": [
+            "currentThreadCount",
+            "currentThreadsBusy"
+          ],
+          "resultAlias": "jboss.threads",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID",
-                        "typeNames" : [ "name" ]
-                     }
-                  }
-               ],
-                "obj" : "jboss.web:type=ThreadPool,name=*",
-      			"resultAlias": "jboss.threads",
-      			"attr" : [ "currentThreadCount", "currentThreadsBusy"]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID",
-                        "typeNames" : [ "name" ]
-                     }
-                  }
-               ],
-                "obj" : "jboss.web:type=GlobalRequestProcessor,name=*",
-      			"resultAlias": "jboss.requests",
-      			"attr" : [ "bytesReceived", "bytesSent", "errorCount", "maxTime", "processingTime", "requestCount"  ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID",
-                        "typeNames" : [ "name" ]
-                     }
-                  }
-               ],
-                "obj" : "jboss.jca:service=ManagedConnectionPool,name=*",
-      			"resultAlias": "jboss.datasources",
-      			"attr" : [ "ConnectionCount", "ConnectionCreatedCount", "InUseConnectionCount",	"MaxConnectionsInUseCount", "AvailableConnectionCount" ]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID",
+                "typeNames": [
+                  "name"
+                ]
+              }
             }
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        },
+        {
+          "obj": "jboss.web:type=GlobalRequestProcessor,name=*",
+          "attr": [
+            "bytesReceived",
+            "bytesSent",
+            "errorCount",
+            "maxTime",
+            "processingTime",
+            "requestCount"
+          ],
+          "resultAlias": "jboss.requests",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID",
+                "typeNames": [
+                  "name"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "obj": "jboss.jca:service=ManagedConnectionPool,name=*",
+          "attr": [
+            "ConnectionCount",
+            "ConnectionCreatedCount",
+            "InUseConnectionCount",
+            "MaxConnectionsInUseCount",
+            "AvailableConnectionCount"
+          ],
+          "resultAlias": "jboss.datasources",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID",
+                "typeNames": [
+                  "name"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/google-cloud-monitoring/json-specify-instance/jvm-sun-hotspot.json
+++ b/jmxtrans/google-cloud-monitoring/json-specify-instance/jvm-sun-hotspot.json
@@ -1,105 +1,105 @@
 {
-   "servers":[
-      {
-         "port":"JMX_PORT",
-         "host":"JMX_HOST",
-         "queries":[
+  "servers": [
+    {
+      "port": "JMX_PORT",
+      "host": "JMX_HOST",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "java.lang:type=Threading",
+          "attr": [
+            "DaemonThreadCount",
+            "ThreadCount",
+            "PeakThreadCount"
+          ],
+          "resultAlias": "jvm.localhost.Threading",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-               "obj": "java.lang:type=Threading",
-               "resultAlias": "jvm.localhost.Threading",
-               "attr":[
-               	  "DaemonThreadCount",
-                  "ThreadCount",
-                  "PeakThreadCount"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-               "obj": "java.lang:type=Memory",
-               "resultAlias": "jvm.localhost.Memory",
-               "attr":[
-                  "HeapMemoryUsage",
-                  "NonHeapMemoryUsage"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-               "obj": "java.lang:type=Runtime",
-               "resultAlias": "jvm.localhost.Runtime",
-               "attr":[
-                  "Uptime"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-               "obj": "java.lang:type=OperatingSystem",
-               "resultAlias": "jvm.localhost.os",
-               "attr":[
-	                "CommittedVirtualMemorySize",
-	                "FreePhysicalMemorySize",
-	                "FreeSwapSpaceSize",
-	                "OpenFileDescriptorCount",
-	                "ProcessCpuTime",
-	                "SystemLoadAverage"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-               "obj": "java.lang:type=GarbageCollector,name=*",
-               "resultAlias": "jvm.localhost.gc",
-               "attr":[
-	                "CollectionCount",
-	                "CollectionTime"
-               ]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
             }
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        },
+        {
+          "obj": "java.lang:type=Memory",
+          "attr": [
+            "HeapMemoryUsage",
+            "NonHeapMemoryUsage"
+          ],
+          "resultAlias": "jvm.localhost.Memory",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "java.lang:type=Runtime",
+          "attr": [
+            "Uptime"
+          ],
+          "resultAlias": "jvm.localhost.Runtime",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "java.lang:type=OperatingSystem",
+          "attr": [
+            "CommittedVirtualMemorySize",
+            "FreePhysicalMemorySize",
+            "FreeSwapSpaceSize",
+            "OpenFileDescriptorCount",
+            "ProcessCpuTime",
+            "SystemLoadAverage"
+          ],
+          "resultAlias": "jvm.localhost.os",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "java.lang:type=GarbageCollector,name=*",
+          "attr": [
+            "CollectionCount",
+            "CollectionTime"
+          ],
+          "resultAlias": "jvm.localhost.gc",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/google-cloud-monitoring/json-specify-instance/kafka.json
+++ b/jmxtrans/google-cloud-monitoring/json-specify-instance/kafka.json
@@ -1,485 +1,549 @@
 {
-  "servers":[
+  "servers": [
     {
       "port": "KAFKA_JMX_PORT",
       "host": "KAFKA_JMX_HOST",
-      "queries":[
+      "queries": [
         {
           "obj": "\"kafka.log\":type=\"LogFlushStats\",name=\"LogFlushRateAndTimeMs\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.log.LogFlushStats.LogFlush",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.server\":type=\"BrokerTopicMetrics\",name=\"AllTopicsBytesInPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.BrokerTopicMetrics.AllTopicsBytesIn",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.server\":type=\"BrokerTopicMetrics\",name=\"AllTopicsFailedFetchRequestsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.BrokerTopicMetrics.AllTopicsFailedFetchRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.server\":type=\"BrokerTopicMetrics\",name=\"AllTopicsFailedProduceRequestsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.BrokerTopicMetrics.AllTopicsFailedProduceRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.server\":type=\"BrokerTopicMetrics\",name=\"AllTopicsMessagesInPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.BrokerTopicMetrics.AllTopicsMessagesIn",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.server\":type=\"BrokerTopicMetrics\",name=\"AllTopicsBytesOutPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.BrokerTopicMetrics.AllTopicsBytesOut",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaManager\",name=\"UnderReplicatedPartitions\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ReplicaManager.UnderReplicatedPartitions",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaManager\",name=\"PartitionCount\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ReplicaManager.PartitionCount",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaManager\",name=\"LeaderCount\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ReplicaManager.LeaderCount",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaManager\",name=\"ISRShrinksPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.ReplicaManager.ISRShrinks",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaManager\",name=\"IsrExpandsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.ReplicaManager.ISRExpands",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaFetcherManager\",name=\"Replica-MaxLag\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ReplicaFetcherManager.MaxLag",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaFetcherManager\",name=\"Replica-MinFetchRate\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ReplicaFetcherManager.MinFetchRate",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.server\":type=\"ProducerRequestPurgatory\",name=\"NumDelayedRequests\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ProducerRequestPurgatory.NumDelayedRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.server\":type=\"ProducerRequestPurgatory\",name=\"PurgatorySize\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ProducerRequestPurgatory.PurgatorySize",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.server\":type=\"FetchRequestPurgatory\",name=\"NumDelayedRequests\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.FetchRequestPurgatory.NumDelayedRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.server\":type=\"FetchRequestPurgatory\",name=\"PurgatorySize\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.FetchRequestPurgatory.PurgatorySize",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.network\":type=\"RequestMetrics\",name=\"Produce-RequestsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.network.RequestMetrics.ProduceRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.network\":type=\"RequestMetrics\",name=\"Fetch-Follower-RequestsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.network.RequestMetrics.FetchFollowerRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.network\":type=\"RequestMetrics\",name=\"Fetch-Consumer-RequestsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.network.RequestMetrics.FetchConsumerRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.controller\":type=\"KafkaController\",name=\"ActiveControllerCount\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.controller.KafkaController.ActiveControllerCount",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.controller\":type=\"KafkaController\",name=\"OfflinePartitionsCount\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.controller.KafkaController.OfflinePartitionsCount",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.controller\":type=\"ControllerStats\",name=\"LeaderElectionRateAndTimeMs\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.controller.ControllerStats.LeaderElection",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.controller\":type=\"ControllerStats\",name=\"UncleanLeaderElectionsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.controller.ControllerStats.UncleanLeaderElection",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.consumer\":type=\"ConsumerFetcherManager\",name=\"*-MaxLag\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.consumer.ConsumerFetcherManager.MaxLag",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.consumer\":type=\"ConsumerFetcherManager\",name=\"*-MinFetchRate\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.consumer.ConsumerFetcherManager.MinFetchRate",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.producer\":type=\"ProducerRequestsMetrics\",name=\"-AllBrokersProducerRequestSize\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.producer.ProducerRequestsMetrics.AllBrokersProducerRequestSize",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.producer\":type=\"ProducerRequestsMetrics\",name=\"-AllBrokersProducerRequestRateAndTimeMs\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.producer.ProducerRequestsMetrics.AllBrokersProducerRequestRate",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.producer\":type=\"ProducerStats\",name=\"-FailedSendsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.producer.ProducerStats.FailedSendsPerSec",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.producer\":type=\"ProducerTopicMetrics\",name=\"-AllTopicsBytesPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.producer.ProducerTopicMetrics.AllTopicsBytes",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.producer\":type=\"ProducerTopicMetrics\",name=\"-AllTopicsDroppedMessagesPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.producer.ProducerTopicMetrics.AllTopicsDroppedMessages",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]
         },
         {
           "obj": "\"kafka.producer\":type=\"ProducerTopicMetrics\",name=\"-AllTopicsMessagesPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.producer.ProducerTopicMetrics.AllTopicsMessages",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "source": "AWS_INSTANCE_ID"
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
               }
             }
           ]

--- a/jmxtrans/google-cloud-monitoring/json-specify-instance/tomcat-7.json
+++ b/jmxtrans/google-cloud-monitoring/json-specify-instance/tomcat-7.json
@@ -1,86 +1,86 @@
 {
-   "servers":[
-      {
-         "port":"TOMCAT_JMX_PORT",
-         "host":"TOMCAT_JMX_HOST",
-         "queries":[
+  "servers": [
+    {
+      "port": "TOMCAT_JMX_PORT",
+      "host": "TOMCAT_JMX_HOST",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "Catalina:type=ThreadPool,name=*",
+          "attr": [
+            "currentThreadCount",
+            "currentThreadsBusy",
+            ""
+          ],
+          "resultAlias": "tomcat.connectors",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-                "obj": "Catalina:type=ThreadPool,name=*",
-            	"resultAlias": "tomcat.connectors",
-            	"attr": [
-                	"currentThreadCount",
-                	"currentThreadsBusy", 
-                	""
-            	]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-                "obj": "Catalina:type=Manager,context=*,host=*",
-            	"resultAlias": "tomcat.manager",
-            	"attr": [
-                	"activeSessions"
-            	]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-                "obj": "Catalina:type=GlobalRequestProcessor,name=*",
-            	"resultAlias": "tomcat.requestProcessor",
-            	"attr": [
-                	"bytesReceived",
-                	"bytesSent",
-                	"errorCount",
-                	"processingTime",
-                	"requestCount"
-            	]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.google.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-                "obj": "Catalina:type=DataSource,context=*,host=*,class=javax.sql.DataSource,name=*",
-            	"resultAlias": "tomcat.data-source",
-            	"attr": [
-                	"numActive",
-                	"numIdle"
-            	]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
             }
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        },
+        {
+          "obj": "Catalina:type=Manager,context=*,host=*",
+          "attr": [
+            "activeSessions"
+          ],
+          "resultAlias": "tomcat.manager",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "Catalina:type=GlobalRequestProcessor,name=*",
+          "attr": [
+            "bytesReceived",
+            "bytesSent",
+            "errorCount",
+            "processingTime",
+            "requestCount"
+          ],
+          "resultAlias": "tomcat.requestProcessor",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "Catalina:type=DataSource,context=*,host=*,class=javax.sql.DataSource,name=*",
+          "attr": [
+            "numActive",
+            "numIdle"
+          ],
+          "resultAlias": "tomcat.data-source",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
+                "source": "GCE_INSTANCE_ID"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/stackdriver/json-detect-instance/README
+++ b/jmxtrans/stackdriver/json-detect-instance/README
@@ -1,0 +1,4 @@
+The files in this directory are automatically generated and will be overwritten.
+If you want to change them, please see
+../../templates/generate-json-files-from-templates.py
+and the .json.tmpl files in that directory.

--- a/jmxtrans/stackdriver/json-detect-instance/activemq_v5.8_basic.json
+++ b/jmxtrans/stackdriver/json-detect-instance/activemq_v5.8_basic.json
@@ -1,45 +1,45 @@
 {
-   "servers":[
-      {
-         "host":"ACTIVEMQ_JMX_HOST",
-         "port":"ACTIVEMQ_JMX_PORT",
-         "queries":[
+  "servers": [
+    {
+      "host": "ACTIVEMQ_JMX_HOST",
+      "port": "ACTIVEMQ_JMX_PORT",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "org.apache.activemq:type=Broker,brokerName=localhost",
+          "attr": [
+            "AverageMessageSize",
+            "CurrentConnectionsCount",
+            "JobSchedulerStoreLimit",
+            "JobSchedulerStorePercentUsage",
+            "MaxMessageSize",
+            "MemoryLimit",
+            "MemoryPercentUsage",
+            "MinMessageSize",
+            "StoreLimit",
+            "StorePercentUsage",
+            "TempLimit",
+            "TempPercentUsage",
+            "TotalConnectionsCount",
+            "TotalConsumerCount",
+            "TotalDequeueCount",
+            "TotalEnqueueCount",
+            "TotalMessageCount",
+            "TotalProducerCount"
+          ],
+          "resultAlias": "sdamq.broker",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-               ],
-               "obj": "org.apache.activemq:type=Broker,brokerName=localhost",
-               "resultAlias": "sdamq.broker",
-               "attr":[
-                  "AverageMessageSize",
-                  "CurrentConnectionsCount",
-                  "JobSchedulerStoreLimit",
-                  "JobSchedulerStorePercentUsage",
-                  "MaxMessageSize",
-                  "MemoryLimit",
-                  "MemoryPercentUsage",
-                  "MinMessageSize",
-                  "StoreLimit",
-                  "StorePercentUsage",
-                  "TempLimit",
-                  "TempPercentUsage",
-                  "TotalConnectionsCount",
-                  "TotalConsumerCount",
-                  "TotalDequeueCount",
-                  "TotalEnqueueCount",
-                  "TotalMessageCount",
-                  "TotalProducerCount"
-               ]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
             }
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/stackdriver/json-detect-instance/activemq_v5.8_expanded.json
+++ b/jmxtrans/stackdriver/json-detect-instance/activemq_v5.8_expanded.json
@@ -1,93 +1,96 @@
 {
-   "servers":[
-      {
-         "host":"ACTIVEMQ_JMX_HOST",
-         "port":"ACTIVEMQ_JMX_PORT",
-         "queries":[
+  "servers": [
+    {
+      "host": "ACTIVEMQ_JMX_HOST",
+      "port": "ACTIVEMQ_JMX_PORT",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "org.apache.activemq:type=Broker,brokerName=localhost",
+          "attr": [
+            "AverageMessageSize",
+            "CurrentConnectionsCount",
+            "JobSchedulerStoreLimit",
+            "JobSchedulerStorePercentUsage",
+            "MaxMessageSize",
+            "MemoryLimit",
+            "MemoryPercentUsage",
+            "MinMessageSize",
+            "StoreLimit",
+            "StorePercentUsage",
+            "TempLimit",
+            "TempPercentUsage",
+            "TotalConnectionsCount",
+            "TotalConsumerCount",
+            "TotalDequeueCount",
+            "TotalEnqueueCount",
+            "TotalMessageCount",
+            "TotalProducerCount"
+          ],
+          "resultAlias": "sdamq.broker",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-               ],
-               "obj": "org.apache.activemq:type=Broker,brokerName=localhost",
-               "resultAlias": "sdamq.broker",
-               "attr":[
-                  "AverageMessageSize",
-                  "CurrentConnectionsCount",
-                  "JobSchedulerStoreLimit",
-                  "JobSchedulerStorePercentUsage",
-                  "MaxMessageSize",
-                  "MemoryLimit",
-                  "MemoryPercentUsage",
-                  "MinMessageSize",
-                  "StoreLimit",
-                  "StorePercentUsage",
-                  "TempLimit",
-                  "TempPercentUsage",
-                  "TotalConnectionsCount",
-                  "TotalConsumerCount",
-                  "TotalDequeueCount",
-                  "TotalEnqueueCount",
-                  "TotalMessageCount",
-                  "TotalProducerCount"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS",
-                        "typeNames" : ["destinationName"]
-                     }
-                  }
-               ],
-               "obj": "org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Topic,destinationName=*",
-               "resultAlias": "activemq.topic",
-               "attr":[
-                  "ConsumerCount",
-                  "ProducerCount",
-                  "EnqueueCount",
-                  "DequeueCount",
-                  "InFlightCount",
-                  "ExpiredCount"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS",
-                        "typeNames" : ["destinationName"]
-                     }
-                  }
-               ],
-               "obj": "org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Queue,destinationName=*",
-               "resultAlias": "activemq.queue",
-               "attr":[
-                  "ConsumerCount",
-                  "ProducerCount",
-                  "QueueSize",
-                  "EnqueueCount",
-                  "DequeueCount",
-                  "InFlightCount",
-                  "ExpiredCount"
-               ]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
             }
-
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        },
+        {
+          "obj": "org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Topic,destinationName=*",
+          "attr": [
+            "ConsumerCount",
+            "ProducerCount",
+            "EnqueueCount",
+            "DequeueCount",
+            "InFlightCount",
+            "ExpiredCount"
+          ],
+          "resultAlias": "activemq.topic",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS",
+                "typeNames": [
+                  "destinationName"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Queue,destinationName=*",
+          "attr": [
+            "ConsumerCount",
+            "ProducerCount",
+            "QueueSize",
+            "EnqueueCount",
+            "DequeueCount",
+            "InFlightCount",
+            "ExpiredCount"
+          ],
+          "resultAlias": "activemq.queue",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS",
+                "typeNames": [
+                  "destinationName"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/stackdriver/json-detect-instance/cassandra-06.json
+++ b/jmxtrans/stackdriver/json-detect-instance/cassandra-06.json
@@ -1,366 +1,366 @@
 {
-   "servers":[
-      {
-         "port":"7199",
-         "host":"localhost",
-         "queries":[
+  "servers": [
+    {
+      "port": "7199",
+      "host": "localhost",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "org.apache.cassandra.db:type=StorageService",
+          "attr": [
+            "Load",
+            "ExceptionCount"
+          ],
+          "resultAlias": "cassandra.storageservice",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-               ],
-               "obj": "org.apache.cassandra.db:type=StorageService",
-               "resultAlias": "cassandra.storageservice",
-               "attr":[
-               		"Load",
-               		"ExceptionCount"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-               ],
-               "obj": "org.apache.cassandra.db:type=Commitlog",
-               "resultAlias": "cassandra.commitlog",
-               "attr":[
-                        "CompletedTasks",
-                        "PendingTasks",
-                        "TotalCommitlogSize"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.db:type=CompactionManager",
-				"resultAlias": "cassandra.compactionmanager",
-				"attr": [
-                        "PendingTasks",
-                        "CompletedTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.concurrent:type=ROW-MUTATION-STAGE",
-				"resultAlias": "cassandra.stage.MutationStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.concurrent:type=CONSISTENCY-MANAGER",
-				"resultAlias": "cassandra.stage.ReadRepairStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.concurrent:type=ROW-READ-STAGE",
-				"resultAlias": "cassandra.stage.ReadStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.request:type=ReplicateOnWriteStage",
-				"resultAlias": "cassandra.stage.ReplicateOnWriteStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.concurrent:type=RESPONSE-STAGE",
-				"resultAlias": "cassandra.stage.RequestResponseStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=AntiEntropySessions",
-				"resultAlias": "cassandra.internal.AntiEntropySessions",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=AntiEntropyStage",
-				"resultAlias": "cassandra.internal.AntiEntropyStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=FlushWriter",
-				"resultAlias": "cassandra.internal.FlushWriter",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=GossipStage",
-				"resultAlias": "cassandra.internal.GossipStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=HintedHandoff",
-				"resultAlias": "cassandra.internal.HintedHandoff",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=InternalResponseStage",
-				"resultAlias": "cassandra.internal.InternalResponseStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=MemtablePostFlusher",
-				"resultAlias": "cassandra.internal.MemtablePostFlusher",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=MigrationStage",
-				"resultAlias": "cassandra.internal.MigrationStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=MiscStage",
-				"resultAlias": "cassandra.internal.MiscStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=StreamStage",
-				"resultAlias": "cassandra.internal.StreamStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
             }
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.db:type=Commitlog",
+          "attr": [
+            "CompletedTasks",
+            "PendingTasks",
+            "TotalCommitlogSize"
+          ],
+          "resultAlias": "cassandra.commitlog",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.db:type=CompactionManager",
+          "attr": [
+            "PendingTasks",
+            "CompletedTasks"
+          ],
+          "resultAlias": "cassandra.compactionmanager",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.concurrent:type=ROW-MUTATION-STAGE",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.stage.MutationStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.concurrent:type=CONSISTENCY-MANAGER",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.stage.ReadRepairStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.concurrent:type=ROW-READ-STAGE",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.stage.ReadStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.request:type=ReplicateOnWriteStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.stage.ReplicateOnWriteStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.concurrent:type=RESPONSE-STAGE",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.stage.RequestResponseStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=AntiEntropySessions",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.AntiEntropySessions",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=AntiEntropyStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.AntiEntropyStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=FlushWriter",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.FlushWriter",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=GossipStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.GossipStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=HintedHandoff",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.HintedHandoff",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=InternalResponseStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.InternalResponseStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=MemtablePostFlusher",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.MemtablePostFlusher",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=MigrationStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.MigrationStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=MiscStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.MiscStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=StreamStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.StreamStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/stackdriver/json-detect-instance/cassandra.json
+++ b/jmxtrans/stackdriver/json-detect-instance/cassandra.json
@@ -1,386 +1,386 @@
 {
-   "servers":[
-      {
-         "port":"7199",
-         "host":"localhost",
-         "queries":[
+  "servers": [
+    {
+      "port": "CASSANDRA_PORT",
+      "host": "CASSANDRA_HOST",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "org.apache.cassandra.db:type=StorageService",
+          "attr": [
+            "Load",
+            "ExceptionCount"
+          ],
+          "resultAlias": "cassandra.storageservice",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-               ],
-               "obj": "org.apache.cassandra.db:type=StorageService",
-               "resultAlias": "cassandra.storageservice",
-               "attr":[
-               		"Load",
-               		"ExceptionCount"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-               ],
-               "obj": "org.apache.cassandra.db:type=Commitlog",
-               "resultAlias": "cassandra.commitlog",
-               "attr":[
-			   	  "CompletedTasks",
-			      "PendingTasks",
-				  "TotalCommitlogSize"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.db:type=CompactionManager",
-				"resultAlias": "cassandra.compactionmanager",
-				"attr": [
-                        "PendingTasks",
-                        "CompletedTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.request:type=MutationStage",
-				"resultAlias": "cassandra.stage.MutationStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.request:type=ReadRepairStage",
-				"resultAlias": "cassandra.stage.ReadRepairStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.request:type=ReadStage",
-				"resultAlias": "cassandra.stage.ReadStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.request:type=ReplicateOnWriteStage",
-				"resultAlias": "cassandra.stage.ReplicateOnWriteStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.request:type=RequestResponseStage",
-				"resultAlias": "cassandra.stage.RequestResponseStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=AntiEntropySessions",
-				"resultAlias": "cassandra.internal.AntiEntropySessions",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=AntiEntropyStage",
-				"resultAlias": "cassandra.internal.AntiEntropyStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=FlushWriter",
-				"resultAlias": "cassandra.internal.FlushWriter",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=GossipStage",
-				"resultAlias": "cassandra.internal.GossipStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=HintedHandoff",
-				"resultAlias": "cassandra.internal.HintedHandoff",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=InternalResponseStage",
-				"resultAlias": "cassandra.internal.InternalResponseStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=MemtablePostFlusher",
-				"resultAlias": "cassandra.internal.MemtablePostFlusher",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=MigrationStage",
-				"resultAlias": "cassandra.internal.MigrationStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=MiscStage",
-				"resultAlias": "cassandra.internal.MiscStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=StreamStage",
-				"resultAlias": "cassandra.internal.StreamStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-              "outputWriters":[
-                  {
-                    "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                    "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                    }
-                  }
-				],
-                "obj": "org.apache.cassandra.db:type=StorageProxy",
-                "resultAlias": "cassandra.internal.StorageProxy",
-                "attr": [
-                        "RecentReadLatencyMicros",
-                        "RecentWriteLatencyMicros",
-                        "RecentRangeLatencyMicros",
-                        "HintsInProgress"
-                ]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
             }
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.db:type=Commitlog",
+          "attr": [
+            "CompletedTasks",
+            "PendingTasks",
+            "TotalCommitlogSize"
+          ],
+          "resultAlias": "cassandra.commitlog",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.db:type=CompactionManager",
+          "attr": [
+            "PendingTasks",
+            "CompletedTasks"
+          ],
+          "resultAlias": "cassandra.compactionmanager",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.request:type=MutationStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.stage.MutationStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.request:type=ReadRepairStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.stage.ReadRepairStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.request:type=ReadStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.stage.ReadStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.request:type=ReplicateOnWriteStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.stage.ReplicateOnWriteStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.request:type=RequestResponseStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.stage.RequestResponseStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=AntiEntropySessions",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.AntiEntropySessions",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=AntiEntropyStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.AntiEntropyStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=FlushWriter",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.FlushWriter",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=GossipStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.GossipStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=HintedHandoff",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.HintedHandoff",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=InternalResponseStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.InternalResponseStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=MemtablePostFlusher",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.MemtablePostFlusher",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=MigrationStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.MigrationStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=MiscStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.MiscStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=StreamStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.StreamStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.db:type=StorageProxy",
+          "attr": [
+            "RecentReadLatencyMicros",
+            "RecentWriteLatencyMicros",
+            "RecentRangeLatencyMicros",
+            "HintsInProgress"
+          ],
+          "resultAlias": "cassandra.internal.StorageProxy",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/stackdriver/json-detect-instance/custom.json
+++ b/jmxtrans/stackdriver/json-detect-instance/custom.json
@@ -1,47 +1,47 @@
 {
-   "servers":[
-      {
-         "port":"JMX PORT",
-         "host":"localhost",
-         "queries":[
+  "servers": [
+    {
+      "port": "JMX PORT",
+      "host": "localhost",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "MBEAN PATH",
+          "attr": [
+            "MBEAN ATTRIBUTE 1",
+            "MBEAN ATTRIBUTE 2",
+            "MBEAN ATTRIBUTE 3"
+          ],
+          "resultAlias": "MYAPP.MYSUBYSTEM.PREFIX",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-               ],
-               "obj": "MBEAN PATH",
-               "resultAlias": "MYAPP.MYSUBYSTEM.PREFIX",
-               "attr":[
-               	  "MBEAN ATTRIBUTE 1",
-                  "MBEAN ATTRIBUTE 2",
-                  "MBEAN ATTRIBUTE 3"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-               ],
-               "obj": "MBEAN 2 PATH",
-               "resultAlias": "MYAPP.MYSUBYSTEM.PREFIX",
-               "attr":[
-               	  "MBEAN ATTRIBUTE"
-               ]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
             }
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        },
+        {
+          "obj": "MBEAN 2 PATH",
+          "attr": [
+            "MBEAN ATTRIBUTE"
+          ],
+          "resultAlias": "MYAPP.MYSUBYSTEM.PREFIX",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/stackdriver/json-detect-instance/hbase_thrift.json
+++ b/jmxtrans/stackdriver/json-detect-instance/hbase_thrift.json
@@ -1,41 +1,55 @@
 {
-  "servers" : [
+  "servers": [
     {
-      "port" : "HBASE_THRIFT_JMX_PORT",
-      "host" : "HBASE_THRIFT_JMX_HOST",
-      "queries" : [
+      "port": "HBASE_THRIFT_JMX_PORT",
+      "host": "HBASE_THRIFT_JMX_HOST",
+      "numQueryThreads": 2,
+      "queries": [
         {
-          "outputWriters" : [
+          "obj": "Hadoop:service=HBase,name=Thrift,sub=ThriftOne",
+          "attr": [
+            "callQueueLen",
+            "SlowThriftCall_mean",
+            "TimeInQueue_mean",
+            "ThriftCall_mean",
+            "BatchGet_mean",
+            "BatchMutate_mean"
+          ],
+          "resultAlias": "sdhbase.Thrift.ThriftOne",
+          "outputWriters": [
             {
-        	  "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
-          ],
-          "obj" : "Hadoop:service=HBase,name=Thrift,sub=ThriftOne",
-          "attr" : [ "callQueueLen", "SlowThriftCall_mean", "TimeInQueue_mean", "ThriftCall_mean", "BatchGet_mean", "BatchMutate_mean" ],
-          "resultAlias": "sdhbase.Thrift.ThriftOne"
+          ]
         },
         {
-          "outputWriters" : [
+          "obj": "Hadoop:service=HBase,name=Thrift,sub=ThriftTwo",
+          "attr": [
+            "callQueueLen",
+            "SlowThriftCall_mean",
+            "TimeInQueue_mean",
+            "ThriftCall_mean",
+            "BatchGet_mean",
+            "BatchMutate_mean"
+          ],
+          "resultAlias": "sdhbase.Thrift.ThriftTwo",
+          "outputWriters": [
             {
-           	  "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
-          ],
-          "obj" : "Hadoop:service=HBase,name=Thrift,sub=ThriftTwo",
-          "attr" : [ "callQueueLen", "SlowThriftCall_mean", "TimeInQueue_mean", "ThriftCall_mean", "BatchGet_mean", "BatchMutate_mean" ],
-          "resultAlias": "sdhbase.Thrift.ThriftTwo"
+          ]
         }
-      ],
-      "numQueryThreads" : 2
+      ]
     }
   ]
 }

--- a/jmxtrans/stackdriver/json-detect-instance/hbase_v0.95.json
+++ b/jmxtrans/stackdriver/json-detect-instance/hbase_v0.95.json
@@ -1,26 +1,53 @@
 {
-  "servers" : [
+  "servers": [
     {
-      "port" : "HBASE_JMX_PORT",
-      "host" : "HBASE_JMX_HOST",
-      "queries" : [
+      "port": "HBASE_JMX_PORT",
+      "host": "HBASE_JMX_HOST",
+      "numQueryThreads": 2,
+      "queries": [
         {
-          "outputWriters" : [
-            {
-        	"@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                "settings": {
-                  "token": "STACKDRIVER_API_KEY",
-                  "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                  "detectInstance": "AWS"
-                }
-              }
+          "obj": "hadoop:service=RegionServer,name=RegionServerStatistics",
+          "attr": [
+            "blockCacheExpressCachingRatio",
+            "blockCacheHitCachingRatio",
+            "callQueueLength",
+            "compactionQueueLength",
+            "compactionQueueSize",
+            "flushQueueSize",
+            "hdfsBlocksLocalityIndex",
+            "memstoreSizeMB",
+            "numberOfOnlineRegions",
+            "readRequestsCount",
+            "slowHLogAppendCount",
+            "usedHeapMB",
+            "writeRequestsCount",
+            "blockCacheCount",
+            "blockCacheEvictedCount",
+            "blockCacheFreeMB",
+            "blockCacheHitCount",
+            "blockCacheMissCount",
+            "blockCacheSizeMB",
+            "fsPreadLatencyNumOps",
+            "fsReadLatencyNumOps",
+            "fsWriteLatencyNumOps",
+            "NumberOfStores",
+            "NumberOfStorefiles",
+            "requestsPerSecond",
+            "storeFileIndexSizeMB"
           ],
-          "obj" : "hadoop:service=RegionServer,name=RegionServerStatistics",
-          "attr" : [ "blockCacheExpressCachingRatio", "blockCacheHitCachingRatio", "callQueueLength", "compactionQueueLength", "compactionQueueSize", "flushQueueSize", "hdfsBlocksLocalityIndex", "memstoreSizeMB", "numberOfOnlineRegions", "readRequestsCount", "slowHLogAppendCount", "usedHeapMB", "writeRequestsCount", "blockCacheCount", "blockCacheEvictedCount", "blockCacheFreeMB", "blockCacheHitCount", "blockCacheMissCount", "blockCacheSizeMB", "fsPreadLatencyNumOps", "fsReadLatencyNumOps", "fsWriteLatencyNumOps", "NumberOfStores", "NumberOfStorefiles", "requestsPerSecond", "storeFileIndexSizeMB" ],
-          "resultAlias": "sdhbase.RegionServer.RegionServerStatistics"
+          "resultAlias": "sdhbase.RegionServer.RegionServerStatistics",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
         }
-      ],
-      "numQueryThreads" : 2
+      ]
     }
   ]
 }

--- a/jmxtrans/stackdriver/json-detect-instance/hbase_v0.98.json
+++ b/jmxtrans/stackdriver/json-detect-instance/hbase_v0.98.json
@@ -1,56 +1,84 @@
 {
-  "servers" : [
+  "servers": [
     {
-      "port" : "HBASE_JMX_PORT",
-      "host" : "HBASE_JMX_HOST",
-      "queries" : [
+      "port": "HBASE_JMX_PORT",
+      "host": "HBASE_JMX_HOST",
+      "numQueryThreads": 3,
+      "queries": [
         {
-          "outputWriters" : [
+          "obj": "Hadoop:service=HBase,name=Master,sub=Server",
+          "attr": [
+            "averageLoad",
+            "numRegionServers",
+            "numDeadRegionServers"
+          ],
+          "resultAlias": "sdhbase.Master.Server",
+          "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
-          ],
-          "obj" : "Hadoop:service=HBase,name=Master,sub=Server",
-          "attr" : [ "averageLoad", "numRegionServers","numDeadRegionServers" ],
-          "resultAlias": "sdhbase.Master.Server"
+          ]
         },
         {
-          "outputWriters" : [
+          "obj": "Hadoop:service=HBase,name=IPC,sub=IPC",
+          "attr": [
+            "sentBytes",
+            "receivedBytes",
+            "queueSize",
+            "numOpenConnections"
+          ],
+          "resultAlias": "sdhbase.IPC.IPC",
+          "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
-          ],
-          "obj" : "Hadoop:service=HBase,name=IPC,sub=IPC",
-          "attr" : [ "sentBytes","receivedBytes","queueSize","numOpenConnections"  ],
-          "resultAlias": "sdhbase.IPC.IPC"
+          ]
         },
         {
-          "outputWriters" : [
+          "obj": "Hadoop:service=HBase,name=RegionServer,sub=Server",
+          "attr": [
+            "blockCacheCount",
+            "blockCacheEvictionCount",
+            "blockCacheFreeSize",
+            "blockCacheHitCount",
+            "blockCountHitPercent",
+            "blockCacheMissCount",
+            "blockCacheSize",
+            "compactionQueueLength",
+            "flushQueueLength",
+            "memStoreSize",
+            "storeCount",
+            "readRequestCount",
+            "storeFileIndexSize",
+            "writeRequestCount",
+            "totalRequestCount",
+            "slowAppendCount",
+            "slowPutCount",
+            "slowGetCount"
+          ],
+          "resultAlias": "sdhbase.RegionServer.RegionServerStatistics",
+          "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
-          ],
-          "obj" : "Hadoop:service=HBase,name=RegionServer,sub=Server",
-          "attr" : [ "blockCacheCount", "blockCacheEvictionCount", "blockCacheFreeSize", "blockCacheHitCount", "blockCountHitPercent", "blockCacheMissCount", "blockCacheSize", "compactionQueueLength", "flushQueueLength", "memStoreSize", "storeCount", "readRequestCount", "storeFileIndexSize", "writeRequestCount", "totalRequestCount", "slowAppendCount", "slowPutCount", "slowGetCount" ],
-          "resultAlias": "sdhbase.RegionServer.RegionServerStatistics"
+          ]
         }
-      ],
-      "numQueryThreads" : 3
+      ]
     }
   ]
 }

--- a/jmxtrans/stackdriver/json-detect-instance/jboss.json
+++ b/jmxtrans/stackdriver/json-detect-instance/jboss.json
@@ -1,59 +1,81 @@
 {
-   "servers":[
-      {
-         "port":"8004",
-         "host":"localhost",
-         "queries":[
+  "servers": [
+    {
+      "port": "8004",
+      "host": "localhost",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "jboss.web:type=ThreadPool,name=*",
+          "attr": [
+            "currentThreadCount",
+            "currentThreadsBusy"
+          ],
+          "resultAlias": "jboss.threads",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS",
-                        "typeNames" : [ "name" ]
-                     }
-                  }
-               ],
-                "obj" : "jboss.web:type=ThreadPool,name=*",
-      			"resultAlias": "jboss.threads",
-      			"attr" : [ "currentThreadCount", "currentThreadsBusy"]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS",
-                        "typeNames" : [ "name" ]
-                     }
-                  }
-               ],
-                "obj" : "jboss.web:type=GlobalRequestProcessor,name=*",
-      			"resultAlias": "jboss.requests",
-      			"attr" : [ "bytesReceived", "bytesSent", "errorCount", "maxTime", "processingTime", "requestCount"  ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS",
-                        "typeNames" : [ "name" ]
-                     }
-                  }
-               ],
-                "obj" : "jboss.jca:service=ManagedConnectionPool,name=*",
-      			"resultAlias": "jboss.datasources",
-      			"attr" : [ "ConnectionCount", "ConnectionCreatedCount", "InUseConnectionCount",	"MaxConnectionsInUseCount", "AvailableConnectionCount" ]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS",
+                "typeNames": [
+                  "name"
+                ]
+              }
             }
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        },
+        {
+          "obj": "jboss.web:type=GlobalRequestProcessor,name=*",
+          "attr": [
+            "bytesReceived",
+            "bytesSent",
+            "errorCount",
+            "maxTime",
+            "processingTime",
+            "requestCount"
+          ],
+          "resultAlias": "jboss.requests",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS",
+                "typeNames": [
+                  "name"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "obj": "jboss.jca:service=ManagedConnectionPool,name=*",
+          "attr": [
+            "ConnectionCount",
+            "ConnectionCreatedCount",
+            "InUseConnectionCount",
+            "MaxConnectionsInUseCount",
+            "AvailableConnectionCount"
+          ],
+          "resultAlias": "jboss.datasources",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS",
+                "typeNames": [
+                  "name"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/stackdriver/json-detect-instance/jvm-sun-hotspot.json
+++ b/jmxtrans/stackdriver/json-detect-instance/jvm-sun-hotspot.json
@@ -1,105 +1,105 @@
 {
-   "servers":[
-      {
-         "port":"JMX_PORT",
-         "host":"JMX_HOST",
-         "queries":[
+  "servers": [
+    {
+      "port": "JMX_PORT",
+      "host": "JMX_HOST",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "java.lang:type=Threading",
+          "attr": [
+            "DaemonThreadCount",
+            "ThreadCount",
+            "PeakThreadCount"
+          ],
+          "resultAlias": "jvm.localhost.Threading",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-               ],
-               "obj": "java.lang:type=Threading",
-               "resultAlias": "jvm.localhost.Threading",
-               "attr":[
-               	  "DaemonThreadCount",
-                  "ThreadCount",
-                  "PeakThreadCount"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-               ],
-               "obj": "java.lang:type=Memory",
-               "resultAlias": "jvm.localhost.Memory",
-               "attr":[
-                  "HeapMemoryUsage",
-                  "NonHeapMemoryUsage"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-               ],
-               "obj": "java.lang:type=Runtime",
-               "resultAlias": "jvm.localhost.Runtime",
-               "attr":[
-                  "Uptime"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-               ],
-               "obj": "java.lang:type=OperatingSystem",
-               "resultAlias": "jvm.localhost.os",
-               "attr":[
-	                "CommittedVirtualMemorySize",
-	                "FreePhysicalMemorySize",
-	                "FreeSwapSpaceSize",
-	                "OpenFileDescriptorCount",
-	                "ProcessCpuTime",
-	                "SystemLoadAverage"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-               ],
-               "obj": "java.lang:type=GarbageCollector,name=*",
-               "resultAlias": "jvm.localhost.gc",
-               "attr":[
-	                "CollectionCount",
-	                "CollectionTime"
-               ]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
             }
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        },
+        {
+          "obj": "java.lang:type=Memory",
+          "attr": [
+            "HeapMemoryUsage",
+            "NonHeapMemoryUsage"
+          ],
+          "resultAlias": "jvm.localhost.Memory",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "java.lang:type=Runtime",
+          "attr": [
+            "Uptime"
+          ],
+          "resultAlias": "jvm.localhost.Runtime",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "java.lang:type=OperatingSystem",
+          "attr": [
+            "CommittedVirtualMemorySize",
+            "FreePhysicalMemorySize",
+            "FreeSwapSpaceSize",
+            "OpenFileDescriptorCount",
+            "ProcessCpuTime",
+            "SystemLoadAverage"
+          ],
+          "resultAlias": "jvm.localhost.os",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "java.lang:type=GarbageCollector,name=*",
+          "attr": [
+            "CollectionCount",
+            "CollectionTime"
+          ],
+          "resultAlias": "jvm.localhost.gc",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/stackdriver/json-detect-instance/kafka.json
+++ b/jmxtrans/stackdriver/json-detect-instance/kafka.json
@@ -1,19 +1,21 @@
 {
-  "servers":[
+  "servers": [
     {
       "port": "KAFKA_JMX_PORT",
       "host": "KAFKA_JMX_HOST",
-      "queries":[
+      "queries": [
         {
           "obj": "\"kafka.log\":type=\"LogFlushStats\",name=\"LogFlushRateAndTimeMs\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.log.LogFlushStats.LogFlush",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -21,14 +23,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"BrokerTopicMetrics\",name=\"AllTopicsBytesInPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.BrokerTopicMetrics.AllTopicsBytesIn",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -36,14 +40,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"BrokerTopicMetrics\",name=\"AllTopicsFailedFetchRequestsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.BrokerTopicMetrics.AllTopicsFailedFetchRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -51,14 +57,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"BrokerTopicMetrics\",name=\"AllTopicsFailedProduceRequestsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.BrokerTopicMetrics.AllTopicsFailedProduceRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -66,14 +74,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"BrokerTopicMetrics\",name=\"AllTopicsMessagesInPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.BrokerTopicMetrics.AllTopicsMessagesIn",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -81,14 +91,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"BrokerTopicMetrics\",name=\"AllTopicsBytesOutPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.BrokerTopicMetrics.AllTopicsBytesOut",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -96,14 +108,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaManager\",name=\"UnderReplicatedPartitions\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ReplicaManager.UnderReplicatedPartitions",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -111,14 +125,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaManager\",name=\"PartitionCount\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ReplicaManager.PartitionCount",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -126,14 +142,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaManager\",name=\"LeaderCount\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ReplicaManager.LeaderCount",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -141,14 +159,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaManager\",name=\"ISRShrinksPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.ReplicaManager.ISRShrinks",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -156,14 +176,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaManager\",name=\"IsrExpandsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.ReplicaManager.ISRExpands",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -171,14 +193,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaFetcherManager\",name=\"Replica-MaxLag\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ReplicaFetcherManager.MaxLag",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -186,14 +210,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaFetcherManager\",name=\"Replica-MinFetchRate\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ReplicaFetcherManager.MinFetchRate",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -201,14 +227,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ProducerRequestPurgatory\",name=\"NumDelayedRequests\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ProducerRequestPurgatory.NumDelayedRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -216,14 +244,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ProducerRequestPurgatory\",name=\"PurgatorySize\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ProducerRequestPurgatory.PurgatorySize",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -231,14 +261,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"FetchRequestPurgatory\",name=\"NumDelayedRequests\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.FetchRequestPurgatory.NumDelayedRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -246,14 +278,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"FetchRequestPurgatory\",name=\"PurgatorySize\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.FetchRequestPurgatory.PurgatorySize",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -261,14 +295,16 @@
         },
         {
           "obj": "\"kafka.network\":type=\"RequestMetrics\",name=\"Produce-RequestsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.network.RequestMetrics.ProduceRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -276,14 +312,16 @@
         },
         {
           "obj": "\"kafka.network\":type=\"RequestMetrics\",name=\"Fetch-Follower-RequestsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.network.RequestMetrics.FetchFollowerRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -291,14 +329,16 @@
         },
         {
           "obj": "\"kafka.network\":type=\"RequestMetrics\",name=\"Fetch-Consumer-RequestsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.network.RequestMetrics.FetchConsumerRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -306,14 +346,16 @@
         },
         {
           "obj": "\"kafka.controller\":type=\"KafkaController\",name=\"ActiveControllerCount\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.controller.KafkaController.ActiveControllerCount",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -321,14 +363,16 @@
         },
         {
           "obj": "\"kafka.controller\":type=\"KafkaController\",name=\"OfflinePartitionsCount\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.controller.KafkaController.OfflinePartitionsCount",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -336,14 +380,16 @@
         },
         {
           "obj": "\"kafka.controller\":type=\"ControllerStats\",name=\"LeaderElectionRateAndTimeMs\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.controller.ControllerStats.LeaderElection",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -351,14 +397,16 @@
         },
         {
           "obj": "\"kafka.controller\":type=\"ControllerStats\",name=\"UncleanLeaderElectionsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.controller.ControllerStats.UncleanLeaderElection",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -366,14 +414,16 @@
         },
         {
           "obj": "\"kafka.consumer\":type=\"ConsumerFetcherManager\",name=\"*-MaxLag\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.consumer.ConsumerFetcherManager.MaxLag",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -381,14 +431,16 @@
         },
         {
           "obj": "\"kafka.consumer\":type=\"ConsumerFetcherManager\",name=\"*-MinFetchRate\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.consumer.ConsumerFetcherManager.MinFetchRate",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -396,14 +448,16 @@
         },
         {
           "obj": "\"kafka.producer\":type=\"ProducerRequestsMetrics\",name=\"-AllBrokersProducerRequestSize\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.producer.ProducerRequestsMetrics.AllBrokersProducerRequestSize",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -411,14 +465,16 @@
         },
         {
           "obj": "\"kafka.producer\":type=\"ProducerRequestsMetrics\",name=\"-AllBrokersProducerRequestRateAndTimeMs\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.producer.ProducerRequestsMetrics.AllBrokersProducerRequestRate",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -426,14 +482,16 @@
         },
         {
           "obj": "\"kafka.producer\":type=\"ProducerStats\",name=\"-FailedSendsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.producer.ProducerStats.FailedSendsPerSec",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -441,14 +499,16 @@
         },
         {
           "obj": "\"kafka.producer\":type=\"ProducerTopicMetrics\",name=\"-AllTopicsBytesPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.producer.ProducerTopicMetrics.AllTopicsBytes",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -456,14 +516,16 @@
         },
         {
           "obj": "\"kafka.producer\":type=\"ProducerTopicMetrics\",name=\"-AllTopicsDroppedMessagesPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.producer.ProducerTopicMetrics.AllTopicsDroppedMessages",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }
@@ -471,14 +533,16 @@
         },
         {
           "obj": "\"kafka.producer\":type=\"ProducerTopicMetrics\",name=\"-AllTopicsMessagesPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.producer.ProducerTopicMetrics.AllTopicsMessages",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "detectInstance": "AWS"
               }
             }

--- a/jmxtrans/stackdriver/json-detect-instance/tomcat-7.json
+++ b/jmxtrans/stackdriver/json-detect-instance/tomcat-7.json
@@ -1,86 +1,86 @@
 {
-   "servers":[
-      {
-         "port":"TOMCAT_JMX_PORT",
-         "host":"TOMCAT_JMX_HOST",
-         "queries":[
+  "servers": [
+    {
+      "port": "TOMCAT_JMX_PORT",
+      "host": "TOMCAT_JMX_HOST",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "Catalina:type=ThreadPool,name=*",
+          "attr": [
+            "currentThreadCount",
+            "currentThreadsBusy",
+            ""
+          ],
+          "resultAlias": "tomcat.connectors",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-               ],
-                "obj": "Catalina:type=ThreadPool,name=*",
-            	"resultAlias": "tomcat.connectors",
-            	"attr": [
-                	"currentThreadCount",
-                	"currentThreadsBusy", 
-                	""
-            	]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-               ],
-                "obj": "Catalina:type=Manager,context=*,host=*",
-            	"resultAlias": "tomcat.manager",
-            	"attr": [
-                	"activeSessions"
-            	]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-               ],
-                "obj": "Catalina:type=GlobalRequestProcessor,name=*",
-            	"resultAlias": "tomcat.requestProcessor",
-            	"attr": [
-                	"bytesReceived",
-                	"bytesSent",
-                	"errorCount",
-                	"processingTime",
-                	"requestCount"
-            	]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "detectInstance": "AWS"
-                     }
-                  }
-               ],
-                "obj": "Catalina:type=DataSource,context=*,host=*,class=javax.sql.DataSource,name=*",
-            	"resultAlias": "tomcat.data-source",
-            	"attr": [
-                	"numActive",
-                	"numIdle"
-            	]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
             }
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        },
+        {
+          "obj": "Catalina:type=Manager,context=*,host=*",
+          "attr": [
+            "activeSessions"
+          ],
+          "resultAlias": "tomcat.manager",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "Catalina:type=GlobalRequestProcessor,name=*",
+          "attr": [
+            "bytesReceived",
+            "bytesSent",
+            "errorCount",
+            "processingTime",
+            "requestCount"
+          ],
+          "resultAlias": "tomcat.requestProcessor",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "Catalina:type=DataSource,context=*,host=*,class=javax.sql.DataSource,name=*",
+          "attr": [
+            "numActive",
+            "numIdle"
+          ],
+          "resultAlias": "tomcat.data-source",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "detectInstance": "AWS"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/stackdriver/json-specify-instance/README
+++ b/jmxtrans/stackdriver/json-specify-instance/README
@@ -1,0 +1,4 @@
+The files in this directory are automatically generated and will be overwritten.
+If you want to change them, please see
+../../templates/generate-json-files-from-templates.py
+and the .json.tmpl files in that directory.

--- a/jmxtrans/stackdriver/json-specify-instance/activemq_v5.8_basic.json
+++ b/jmxtrans/stackdriver/json-specify-instance/activemq_v5.8_basic.json
@@ -1,45 +1,45 @@
 {
-   "servers":[
-      {
-         "host":"ACTIVEMQ_JMX_HOST",
-         "port":"ACTIVEMQ_JMX_PORT",
-         "queries":[
+  "servers": [
+    {
+      "host": "ACTIVEMQ_JMX_HOST",
+      "port": "ACTIVEMQ_JMX_PORT",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "org.apache.activemq:type=Broker,brokerName=localhost",
+          "attr": [
+            "AverageMessageSize",
+            "CurrentConnectionsCount",
+            "JobSchedulerStoreLimit",
+            "JobSchedulerStorePercentUsage",
+            "MaxMessageSize",
+            "MemoryLimit",
+            "MemoryPercentUsage",
+            "MinMessageSize",
+            "StoreLimit",
+            "StorePercentUsage",
+            "TempLimit",
+            "TempPercentUsage",
+            "TotalConnectionsCount",
+            "TotalConsumerCount",
+            "TotalDequeueCount",
+            "TotalEnqueueCount",
+            "TotalMessageCount",
+            "TotalProducerCount"
+          ],
+          "resultAlias": "sdamq.broker",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "INSTANCE_ID"
-                     }
-                  }
-               ],
-               "obj": "org.apache.activemq:type=Broker,brokerName=localhost",
-               "resultAlias": "sdamq.broker",
-               "attr":[
-                  "AverageMessageSize",
-                  "CurrentConnectionsCount",
-                  "JobSchedulerStoreLimit",
-                  "JobSchedulerStorePercentUsage",
-                  "MaxMessageSize",
-                  "MemoryLimit",
-                  "MemoryPercentUsage",
-                  "MinMessageSize",
-                  "StoreLimit",
-                  "StorePercentUsage",
-                  "TempLimit",
-                  "TempPercentUsage",
-                  "TotalConnectionsCount",
-                  "TotalConsumerCount",
-                  "TotalDequeueCount",
-                  "TotalEnqueueCount",
-                  "TotalMessageCount",
-                  "TotalProducerCount"
-               ]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
             }
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/stackdriver/json-specify-instance/activemq_v5.8_expanded.json
+++ b/jmxtrans/stackdriver/json-specify-instance/activemq_v5.8_expanded.json
@@ -1,93 +1,96 @@
 {
-   "servers":[
-      {
-         "host":"ACTIVEMQ_JMX_HOST",
-         "port":"ACTIVEMQ_JMX_PORT",
-         "queries":[
+  "servers": [
+    {
+      "host": "ACTIVEMQ_JMX_HOST",
+      "port": "ACTIVEMQ_JMX_PORT",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "org.apache.activemq:type=Broker,brokerName=localhost",
+          "attr": [
+            "AverageMessageSize",
+            "CurrentConnectionsCount",
+            "JobSchedulerStoreLimit",
+            "JobSchedulerStorePercentUsage",
+            "MaxMessageSize",
+            "MemoryLimit",
+            "MemoryPercentUsage",
+            "MinMessageSize",
+            "StoreLimit",
+            "StorePercentUsage",
+            "TempLimit",
+            "TempPercentUsage",
+            "TotalConnectionsCount",
+            "TotalConsumerCount",
+            "TotalDequeueCount",
+            "TotalEnqueueCount",
+            "TotalMessageCount",
+            "TotalProducerCount"
+          ],
+          "resultAlias": "sdamq.broker",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "INSTANCE_ID"
-                     }
-                  }
-               ],
-               "obj": "org.apache.activemq:type=Broker,brokerName=localhost",
-               "resultAlias": "sdamq.broker",
-               "attr":[
-                  "AverageMessageSize",
-                  "CurrentConnectionsCount",
-                  "JobSchedulerStoreLimit",
-                  "JobSchedulerStorePercentUsage",
-                  "MaxMessageSize",
-                  "MemoryLimit",
-                  "MemoryPercentUsage",
-                  "MinMessageSize",
-                  "StoreLimit",
-                  "StorePercentUsage",
-                  "TempLimit",
-                  "TempPercentUsage",
-                  "TotalConnectionsCount",
-                  "TotalConsumerCount",
-                  "TotalDequeueCount",
-                  "TotalEnqueueCount",
-                  "TotalMessageCount",
-                  "TotalProducerCount"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "INSTANCE_ID",
-                        "typeNames" : ["destinationName"]
-                     }
-                  }
-               ],
-               "obj": "org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Topic,destinationName=*",
-               "resultAlias": "activemq.topic",
-               "attr":[
-                  "ConsumerCount",
-                  "ProducerCount",
-                  "EnqueueCount",
-                  "DequeueCount",
-                  "InFlightCount",
-                  "ExpiredCount"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "INSTANCE_ID",
-                        "typeNames" : ["destinationName"]
-                     }
-                  }
-               ],
-               "obj": "org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Queue,destinationName=*",
-               "resultAlias": "activemq.queue",
-               "attr":[
-                  "ConsumerCount",
-                  "ProducerCount",
-                  "QueueSize",
-                  "EnqueueCount",
-                  "DequeueCount",
-                  "InFlightCount",
-                  "ExpiredCount"
-               ]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
             }
-
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        },
+        {
+          "obj": "org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Topic,destinationName=*",
+          "attr": [
+            "ConsumerCount",
+            "ProducerCount",
+            "EnqueueCount",
+            "DequeueCount",
+            "InFlightCount",
+            "ExpiredCount"
+          ],
+          "resultAlias": "activemq.topic",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID",
+                "typeNames": [
+                  "destinationName"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Queue,destinationName=*",
+          "attr": [
+            "ConsumerCount",
+            "ProducerCount",
+            "QueueSize",
+            "EnqueueCount",
+            "DequeueCount",
+            "InFlightCount",
+            "ExpiredCount"
+          ],
+          "resultAlias": "activemq.queue",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID",
+                "typeNames": [
+                  "destinationName"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/stackdriver/json-specify-instance/cassandra-06.json
+++ b/jmxtrans/stackdriver/json-specify-instance/cassandra-06.json
@@ -1,8 +1,8 @@
 {
   "servers": [
     {
-      "port": "CASSANDRA_PORT",
-      "host": "CASSANDRA_HOST",
+      "port": "7199",
+      "host": "localhost",
       "numQueryThreads": 2,
       "queries": [
         {
@@ -17,8 +17,8 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
               }
             }
           ]
@@ -36,8 +36,8 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
               }
             }
           ]
@@ -54,14 +54,14 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
               }
             }
           ]
         },
         {
-          "obj": "org.apache.cassandra.request:type=MutationStage",
+          "obj": "org.apache.cassandra.concurrent:type=ROW-MUTATION-STAGE",
           "attr": [
             "ActiveCount",
             "CompletedTasks",
@@ -74,14 +74,14 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
               }
             }
           ]
         },
         {
-          "obj": "org.apache.cassandra.request:type=ReadRepairStage",
+          "obj": "org.apache.cassandra.concurrent:type=CONSISTENCY-MANAGER",
           "attr": [
             "ActiveCount",
             "CompletedTasks",
@@ -94,14 +94,14 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
               }
             }
           ]
         },
         {
-          "obj": "org.apache.cassandra.request:type=ReadStage",
+          "obj": "org.apache.cassandra.concurrent:type=ROW-READ-STAGE",
           "attr": [
             "ActiveCount",
             "CompletedTasks",
@@ -114,8 +114,8 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
               }
             }
           ]
@@ -134,14 +134,14 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
               }
             }
           ]
         },
         {
-          "obj": "org.apache.cassandra.request:type=RequestResponseStage",
+          "obj": "org.apache.cassandra.concurrent:type=RESPONSE-STAGE",
           "attr": [
             "ActiveCount",
             "CompletedTasks",
@@ -154,8 +154,8 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
               }
             }
           ]
@@ -174,8 +174,8 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
               }
             }
           ]
@@ -194,8 +194,8 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
               }
             }
           ]
@@ -214,8 +214,8 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
               }
             }
           ]
@@ -234,8 +234,8 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
               }
             }
           ]
@@ -254,8 +254,8 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
               }
             }
           ]
@@ -274,8 +274,8 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
               }
             }
           ]
@@ -294,8 +294,8 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
               }
             }
           ]
@@ -314,8 +314,8 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
               }
             }
           ]
@@ -334,8 +334,8 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
               }
             }
           ]
@@ -354,28 +354,8 @@
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
-              }
-            }
-          ]
-        },
-        {
-          "obj": "org.apache.cassandra.db:type=StorageProxy",
-          "attr": [
-            "RecentReadLatencyMicros",
-            "RecentWriteLatencyMicros",
-            "RecentRangeLatencyMicros",
-            "HintsInProgress"
-          ],
-          "resultAlias": "cassandra.internal.StorageProxy",
-          "outputWriters": [
-            {
-              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
-              "settings": {
-                "token": "STACKDRIVER_API_KEY",
-                "url": "https://jmx-gateway.google.stackdriver.com/v1/custom",
-                "detectInstance": "GCE"
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
               }
             }
           ]

--- a/jmxtrans/stackdriver/json-specify-instance/cassandra.json
+++ b/jmxtrans/stackdriver/json-specify-instance/cassandra.json
@@ -1,386 +1,386 @@
 {
-   "servers":[
-      {
-         "port":"CASSANDRA_PORT",
-         "host":"CASSANDRA_HOST",
-         "queries":[
+  "servers": [
+    {
+      "port": "CASSANDRA_PORT",
+      "host": "CASSANDRA_HOST",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "org.apache.cassandra.db:type=StorageService",
+          "attr": [
+            "Load",
+            "ExceptionCount"
+          ],
+          "resultAlias": "cassandra.storageservice",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-               "obj": "org.apache.cassandra.db:type=StorageService",
-               "resultAlias": "cassandra.storageservice",
-               "attr":[
-               		"Load",
-               		"ExceptionCount"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-               "obj": "org.apache.cassandra.db:type=Commitlog",
-               "resultAlias": "cassandra.commitlog",
-               "attr":[
-			   	  "CompletedTasks",
-			      "PendingTasks",
-				  "TotalCommitlogSize"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.db:type=CompactionManager",
-				"resultAlias": "cassandra.compactionmanager",
-				"attr": [
-                        "PendingTasks",
-                        "CompletedTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.request:type=MutationStage",
-				"resultAlias": "cassandra.stage.MutationStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.request:type=ReadRepairStage",
-				"resultAlias": "cassandra.stage.ReadRepairStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.request:type=ReadStage",
-				"resultAlias": "cassandra.stage.ReadStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.request:type=ReplicateOnWriteStage",
-				"resultAlias": "cassandra.stage.ReplicateOnWriteStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.request:type=RequestResponseStage",
-				"resultAlias": "cassandra.stage.RequestResponseStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=AntiEntropySessions",
-				"resultAlias": "cassandra.internal.AntiEntropySessions",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=AntiEntropyStage",
-				"resultAlias": "cassandra.internal.AntiEntropyStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=FlushWriter",
-				"resultAlias": "cassandra.internal.FlushWriter",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=GossipStage",
-				"resultAlias": "cassandra.internal.GossipStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=HintedHandoff",
-				"resultAlias": "cassandra.internal.HintedHandoff",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=InternalResponseStage",
-				"resultAlias": "cassandra.internal.InternalResponseStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=MemtablePostFlusher",
-				"resultAlias": "cassandra.internal.MemtablePostFlusher",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=MigrationStage",
-				"resultAlias": "cassandra.internal.MigrationStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=MiscStage",
-				"resultAlias": "cassandra.internal.MiscStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-				],
-				"obj": "org.apache.cassandra.internal:type=StreamStage",
-				"resultAlias": "cassandra.internal.StreamStage",
-				"attr": [
-                        "ActiveCount",
-                        "CompletedTasks",
-                        "CurrentlyBlockedTasks",
-                        "PendingTasks"
-				]
-            },
-            {
-              "outputWriters":[
-                  {
-                    "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                    "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                    }
-                  }
-				],
-                "obj": "org.apache.cassandra.db:type=StorageProxy",
-                "resultAlias": "cassandra.internal.StorageProxy",
-                "attr": [
-                        "RecentReadLatencyMicros",
-                        "RecentWriteLatencyMicros",
-                        "RecentRangeLatencyMicros",
-                        "HintsInProgress"
-                ]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
             }
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.db:type=Commitlog",
+          "attr": [
+            "CompletedTasks",
+            "PendingTasks",
+            "TotalCommitlogSize"
+          ],
+          "resultAlias": "cassandra.commitlog",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.db:type=CompactionManager",
+          "attr": [
+            "PendingTasks",
+            "CompletedTasks"
+          ],
+          "resultAlias": "cassandra.compactionmanager",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.request:type=MutationStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.stage.MutationStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.request:type=ReadRepairStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.stage.ReadRepairStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.request:type=ReadStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.stage.ReadStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.request:type=ReplicateOnWriteStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.stage.ReplicateOnWriteStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.request:type=RequestResponseStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.stage.RequestResponseStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=AntiEntropySessions",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.AntiEntropySessions",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=AntiEntropyStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.AntiEntropyStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=FlushWriter",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.FlushWriter",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=GossipStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.GossipStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=HintedHandoff",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.HintedHandoff",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=InternalResponseStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.InternalResponseStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=MemtablePostFlusher",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.MemtablePostFlusher",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=MigrationStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.MigrationStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=MiscStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.MiscStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.internal:type=StreamStage",
+          "attr": [
+            "ActiveCount",
+            "CompletedTasks",
+            "CurrentlyBlockedTasks",
+            "PendingTasks"
+          ],
+          "resultAlias": "cassandra.internal.StreamStage",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "org.apache.cassandra.db:type=StorageProxy",
+          "attr": [
+            "RecentReadLatencyMicros",
+            "RecentWriteLatencyMicros",
+            "RecentRangeLatencyMicros",
+            "HintsInProgress"
+          ],
+          "resultAlias": "cassandra.internal.StorageProxy",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/stackdriver/json-specify-instance/custom.json
+++ b/jmxtrans/stackdriver/json-specify-instance/custom.json
@@ -1,47 +1,47 @@
 {
-   "servers":[
-      {
-         "port":"JMX PORT",
-         "host":"localhost",
-         "queries":[
+  "servers": [
+    {
+      "port": "JMX PORT",
+      "host": "localhost",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "MBEAN PATH",
+          "attr": [
+            "MBEAN ATTRIBUTE 1",
+            "MBEAN ATTRIBUTE 2",
+            "MBEAN ATTRIBUTE 3"
+          ],
+          "resultAlias": "MYAPP.MYSUBYSTEM.PREFIX",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-               "obj": "MBEAN PATH",
-               "resultAlias": "MYAPP.MYSUBYSTEM.PREFIX",
-               "attr":[
-               	  "MBEAN ATTRIBUTE 1",
-                  "MBEAN ATTRIBUTE 2",
-                  "MBEAN ATTRIBUTE 3"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-               "obj": "MBEAN 2 PATH",
-               "resultAlias": "MYAPP.MYSUBYSTEM.PREFIX",
-               "attr":[
-               	  "MBEAN ATTRIBUTE"
-               ]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
             }
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        },
+        {
+          "obj": "MBEAN 2 PATH",
+          "attr": [
+            "MBEAN ATTRIBUTE"
+          ],
+          "resultAlias": "MYAPP.MYSUBYSTEM.PREFIX",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/stackdriver/json-specify-instance/hbase_thrift.json
+++ b/jmxtrans/stackdriver/json-specify-instance/hbase_thrift.json
@@ -1,41 +1,55 @@
 {
-  "servers" : [
+  "servers": [
     {
-      "port" : "HBASE_THRIFT_JMX_PORT",
-      "host" : "HBASE_THRIFT_JMX_HOST",
-      "queries" : [
+      "port": "HBASE_THRIFT_JMX_PORT",
+      "host": "HBASE_THRIFT_JMX_HOST",
+      "numQueryThreads": 2,
+      "queries": [
         {
-          "outputWriters" : [
+          "obj": "Hadoop:service=HBase,name=Thrift,sub=ThriftOne",
+          "attr": [
+            "callQueueLen",
+            "SlowThriftCall_mean",
+            "TimeInQueue_mean",
+            "ThriftCall_mean",
+            "BatchGet_mean",
+            "BatchMutate_mean"
+          ],
+          "resultAlias": "sdhbase.Thrift.ThriftOne",
+          "outputWriters": [
             {
-        	  "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
-          ],
-          "obj" : "Hadoop:service=HBase,name=Thrift,sub=ThriftOne",
-          "attr" : [ "callQueueLen", "SlowThriftCall_mean", "TimeInQueue_mean", "ThriftCall_mean", "BatchGet_mean", "BatchMutate_mean" ],
-          "resultAlias": "sdhbase.Thrift.ThriftOne"
+          ]
         },
         {
-          "outputWriters" : [
+          "obj": "Hadoop:service=HBase,name=Thrift,sub=ThriftTwo",
+          "attr": [
+            "callQueueLen",
+            "SlowThriftCall_mean",
+            "TimeInQueue_mean",
+            "ThriftCall_mean",
+            "BatchGet_mean",
+            "BatchMutate_mean"
+          ],
+          "resultAlias": "sdhbase.Thrift.ThriftTwo",
+          "outputWriters": [
             {
-           	  "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
-          ],
-          "obj" : "Hadoop:service=HBase,name=Thrift,sub=ThriftTwo",
-          "attr" : [ "callQueueLen", "SlowThriftCall_mean", "TimeInQueue_mean", "ThriftCall_mean", "BatchGet_mean", "BatchMutate_mean" ],
-          "resultAlias": "sdhbase.Thrift.ThriftTwo"
+          ]
         }
-      ],
-      "numQueryThreads" : 2
+      ]
     }
   ]
 }

--- a/jmxtrans/stackdriver/json-specify-instance/hbase_v0.95.json
+++ b/jmxtrans/stackdriver/json-specify-instance/hbase_v0.95.json
@@ -1,26 +1,53 @@
 {
-  "servers" : [
+  "servers": [
     {
-      "port" : "HBASE_JMX_PORT",
-      "host" : "HBASE_JMX_HOST",
-      "queries" : [
+      "port": "HBASE_JMX_PORT",
+      "host": "HBASE_JMX_HOST",
+      "numQueryThreads": 2,
+      "queries": [
         {
-          "outputWriters" : [
-            {
-                "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                "settings": {
-                  "token": "STACKDRIVER_API_KEY",
-                  "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                  "source": "AWS_INSTANCE_ID"
-                }
-              }
+          "obj": "hadoop:service=RegionServer,name=RegionServerStatistics",
+          "attr": [
+            "blockCacheExpressCachingRatio",
+            "blockCacheHitCachingRatio",
+            "callQueueLength",
+            "compactionQueueLength",
+            "compactionQueueSize",
+            "flushQueueSize",
+            "hdfsBlocksLocalityIndex",
+            "memstoreSizeMB",
+            "numberOfOnlineRegions",
+            "readRequestsCount",
+            "slowHLogAppendCount",
+            "usedHeapMB",
+            "writeRequestsCount",
+            "blockCacheCount",
+            "blockCacheEvictedCount",
+            "blockCacheFreeMB",
+            "blockCacheHitCount",
+            "blockCacheMissCount",
+            "blockCacheSizeMB",
+            "fsPreadLatencyNumOps",
+            "fsReadLatencyNumOps",
+            "fsWriteLatencyNumOps",
+            "NumberOfStores",
+            "NumberOfStorefiles",
+            "requestsPerSecond",
+            "storeFileIndexSizeMB"
           ],
-          "obj" : "hadoop:service=RegionServer,name=RegionServerStatistics",
-          "attr" : [ "blockCacheExpressCachingRatio", "blockCacheHitCachingRatio", "callQueueLength", "compactionQueueLength", "compactionQueueSize", "flushQueueSize", "hdfsBlocksLocalityIndex", "memstoreSizeMB", "numberOfOnlineRegions", "readRequestsCount", "slowHLogAppendCount", "usedHeapMB", "writeRequestsCount", "blockCacheCount", "blockCacheEvictedCount", "blockCacheFreeMB", "blockCacheHitCount", "blockCacheMissCount", "blockCacheSizeMB", "fsPreadLatencyNumOps", "fsReadLatencyNumOps", "fsWriteLatencyNumOps", "NumberOfStores", "NumberOfStorefiles", "requestsPerSecond", "storeFileIndexSizeMB" ],
-          "resultAlias": "sdhbase.RegionServer.RegionServerStatistics"
+          "resultAlias": "sdhbase.RegionServer.RegionServerStatistics",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
         }
-      ],
-      "numQueryThreads" : 2
+      ]
     }
   ]
 }

--- a/jmxtrans/stackdriver/json-specify-instance/hbase_v0.98.json
+++ b/jmxtrans/stackdriver/json-specify-instance/hbase_v0.98.json
@@ -1,56 +1,84 @@
 {
-  "servers" : [
+  "servers": [
     {
-      "port" : "HBASE_JMX_PORT",
-      "host" : "HBASE_JMX_HOST",
-      "queries" : [
+      "port": "HBASE_JMX_PORT",
+      "host": "HBASE_JMX_HOST",
+      "numQueryThreads": 3,
+      "queries": [
         {
-          "outputWriters" : [
+          "obj": "Hadoop:service=HBase,name=Master,sub=Server",
+          "attr": [
+            "averageLoad",
+            "numRegionServers",
+            "numDeadRegionServers"
+          ],
+          "resultAlias": "sdhbase.Master.Server",
+          "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
-          ],
-          "obj" : "Hadoop:service=HBase,name=Master,sub=Server",
-          "attr" : [ "averageLoad", "numRegionServers","numDeadRegionServers" ],
-          "resultAlias": "sdhbase.Master.Server"
+          ]
         },
         {
-          "outputWriters" : [
+          "obj": "Hadoop:service=HBase,name=IPC,sub=IPC",
+          "attr": [
+            "sentBytes",
+            "receivedBytes",
+            "queueSize",
+            "numOpenConnections"
+          ],
+          "resultAlias": "sdhbase.IPC.IPC",
+          "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
-          ],
-          "obj" : "Hadoop:service=HBase,name=IPC,sub=IPC",
-          "attr" : [ "sentBytes","receivedBytes","queueSize","numOpenConnections"  ],
-          "resultAlias": "sdhbase.IPC.IPC"
+          ]
         },
         {
-          "outputWriters" : [
+          "obj": "Hadoop:service=HBase,name=RegionServer,sub=Server",
+          "attr": [
+            "blockCacheCount",
+            "blockCacheEvictionCount",
+            "blockCacheFreeSize",
+            "blockCacheHitCount",
+            "blockCountHitPercent",
+            "blockCacheMissCount",
+            "blockCacheSize",
+            "compactionQueueLength",
+            "flushQueueLength",
+            "memStoreSize",
+            "storeCount",
+            "readRequestCount",
+            "storeFileIndexSize",
+            "writeRequestCount",
+            "totalRequestCount",
+            "slowAppendCount",
+            "slowPutCount",
+            "slowGetCount"
+          ],
+          "resultAlias": "sdhbase.RegionServer.RegionServerStatistics",
+          "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
-          ],
-          "obj" : "Hadoop:service=HBase,name=RegionServer,sub=Server",
-          "attr" : [ "blockCacheCount", "blockCacheEvictionCount", "blockCacheFreeSize", "blockCacheHitCount", "blockCountHitPercent", "blockCacheMissCount", "blockCacheSize", "compactionQueueLength", "flushQueueLength", "memStoreSize", "storeCount", "readRequestCount", "storeFileIndexSize", "writeRequestCount", "totalRequestCount", "slowAppendCount", "slowPutCount", "slowGetCount" ],
-          "resultAlias": "sdhbase.RegionServer.RegionServerStatistics"
+          ]
         }
-      ],
-      "numQueryThreads" : 3
+      ]
     }
   ]
 }

--- a/jmxtrans/stackdriver/json-specify-instance/jboss.json
+++ b/jmxtrans/stackdriver/json-specify-instance/jboss.json
@@ -1,59 +1,81 @@
 {
-   "servers":[
-      {
-         "port":"8004",
-         "host":"localhost",
-         "queries":[
+  "servers": [
+    {
+      "port": "8004",
+      "host": "localhost",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "jboss.web:type=ThreadPool,name=*",
+          "attr": [
+            "currentThreadCount",
+            "currentThreadsBusy"
+          ],
+          "resultAlias": "jboss.threads",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID",
-                        "typeNames" : [ "name" ]
-                     }
-                  }
-               ],
-                "obj" : "jboss.web:type=ThreadPool,name=*",
-      			"resultAlias": "jboss.threads",
-      			"attr" : [ "currentThreadCount", "currentThreadsBusy"]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID",
-                        "typeNames" : [ "name" ]
-                     }
-                  }
-               ],
-                "obj" : "jboss.web:type=GlobalRequestProcessor,name=*",
-      			"resultAlias": "jboss.requests",
-      			"attr" : [ "bytesReceived", "bytesSent", "errorCount", "maxTime", "processingTime", "requestCount"  ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID",
-                        "typeNames" : [ "name" ]
-                     }
-                  }
-               ],
-                "obj" : "jboss.jca:service=ManagedConnectionPool,name=*",
-      			"resultAlias": "jboss.datasources",
-      			"attr" : [ "ConnectionCount", "ConnectionCreatedCount", "InUseConnectionCount",	"MaxConnectionsInUseCount", "AvailableConnectionCount" ]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID",
+                "typeNames": [
+                  "name"
+                ]
+              }
             }
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        },
+        {
+          "obj": "jboss.web:type=GlobalRequestProcessor,name=*",
+          "attr": [
+            "bytesReceived",
+            "bytesSent",
+            "errorCount",
+            "maxTime",
+            "processingTime",
+            "requestCount"
+          ],
+          "resultAlias": "jboss.requests",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID",
+                "typeNames": [
+                  "name"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "obj": "jboss.jca:service=ManagedConnectionPool,name=*",
+          "attr": [
+            "ConnectionCount",
+            "ConnectionCreatedCount",
+            "InUseConnectionCount",
+            "MaxConnectionsInUseCount",
+            "AvailableConnectionCount"
+          ],
+          "resultAlias": "jboss.datasources",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID",
+                "typeNames": [
+                  "name"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/stackdriver/json-specify-instance/jvm-sun-hotspot.json
+++ b/jmxtrans/stackdriver/json-specify-instance/jvm-sun-hotspot.json
@@ -1,105 +1,105 @@
 {
-   "servers":[
-      {
-         "port":"JMX_PORT",
-         "host":"JMX_HOST",
-         "queries":[
+  "servers": [
+    {
+      "port": "JMX_PORT",
+      "host": "JMX_HOST",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "java.lang:type=Threading",
+          "attr": [
+            "DaemonThreadCount",
+            "ThreadCount",
+            "PeakThreadCount"
+          ],
+          "resultAlias": "jvm.localhost.Threading",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-               "obj": "java.lang:type=Threading",
-               "resultAlias": "jvm.localhost.Threading",
-               "attr":[
-               	  "DaemonThreadCount",
-                  "ThreadCount",
-                  "PeakThreadCount"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-               "obj": "java.lang:type=Memory",
-               "resultAlias": "jvm.localhost.Memory",
-               "attr":[
-                  "HeapMemoryUsage",
-                  "NonHeapMemoryUsage"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-               "obj": "java.lang:type=Runtime",
-               "resultAlias": "jvm.localhost.Runtime",
-               "attr":[
-                  "Uptime"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-               "obj": "java.lang:type=OperatingSystem",
-               "resultAlias": "jvm.localhost.os",
-               "attr":[
-	                "CommittedVirtualMemorySize",
-	                "FreePhysicalMemorySize",
-	                "FreeSwapSpaceSize",
-	                "OpenFileDescriptorCount",
-	                "ProcessCpuTime",
-	                "SystemLoadAverage"
-               ]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-               "obj": "java.lang:type=GarbageCollector,name=*",
-               "resultAlias": "jvm.localhost.gc",
-               "attr":[
-	                "CollectionCount",
-	                "CollectionTime"
-               ]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
             }
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        },
+        {
+          "obj": "java.lang:type=Memory",
+          "attr": [
+            "HeapMemoryUsage",
+            "NonHeapMemoryUsage"
+          ],
+          "resultAlias": "jvm.localhost.Memory",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "java.lang:type=Runtime",
+          "attr": [
+            "Uptime"
+          ],
+          "resultAlias": "jvm.localhost.Runtime",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "java.lang:type=OperatingSystem",
+          "attr": [
+            "CommittedVirtualMemorySize",
+            "FreePhysicalMemorySize",
+            "FreeSwapSpaceSize",
+            "OpenFileDescriptorCount",
+            "ProcessCpuTime",
+            "SystemLoadAverage"
+          ],
+          "resultAlias": "jvm.localhost.os",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "java.lang:type=GarbageCollector,name=*",
+          "attr": [
+            "CollectionCount",
+            "CollectionTime"
+          ],
+          "resultAlias": "jvm.localhost.gc",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/stackdriver/json-specify-instance/kafka.json
+++ b/jmxtrans/stackdriver/json-specify-instance/kafka.json
@@ -1,19 +1,21 @@
 {
-  "servers":[
+  "servers": [
     {
       "port": "KAFKA_JMX_PORT",
       "host": "KAFKA_JMX_HOST",
-      "queries":[
+      "queries": [
         {
           "obj": "\"kafka.log\":type=\"LogFlushStats\",name=\"LogFlushRateAndTimeMs\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.log.LogFlushStats.LogFlush",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -21,14 +23,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"BrokerTopicMetrics\",name=\"AllTopicsBytesInPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.BrokerTopicMetrics.AllTopicsBytesIn",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -36,14 +40,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"BrokerTopicMetrics\",name=\"AllTopicsFailedFetchRequestsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.BrokerTopicMetrics.AllTopicsFailedFetchRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -51,14 +57,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"BrokerTopicMetrics\",name=\"AllTopicsFailedProduceRequestsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.BrokerTopicMetrics.AllTopicsFailedProduceRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -66,14 +74,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"BrokerTopicMetrics\",name=\"AllTopicsMessagesInPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.BrokerTopicMetrics.AllTopicsMessagesIn",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -81,14 +91,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"BrokerTopicMetrics\",name=\"AllTopicsBytesOutPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.BrokerTopicMetrics.AllTopicsBytesOut",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -96,14 +108,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaManager\",name=\"UnderReplicatedPartitions\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ReplicaManager.UnderReplicatedPartitions",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -111,14 +125,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaManager\",name=\"PartitionCount\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ReplicaManager.PartitionCount",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -126,14 +142,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaManager\",name=\"LeaderCount\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ReplicaManager.LeaderCount",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -141,14 +159,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaManager\",name=\"ISRShrinksPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.ReplicaManager.ISRShrinks",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -156,14 +176,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaManager\",name=\"IsrExpandsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.server.ReplicaManager.ISRExpands",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -171,14 +193,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaFetcherManager\",name=\"Replica-MaxLag\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ReplicaFetcherManager.MaxLag",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -186,14 +210,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ReplicaFetcherManager\",name=\"Replica-MinFetchRate\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ReplicaFetcherManager.MinFetchRate",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -201,14 +227,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ProducerRequestPurgatory\",name=\"NumDelayedRequests\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ProducerRequestPurgatory.NumDelayedRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -216,14 +244,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"ProducerRequestPurgatory\",name=\"PurgatorySize\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.ProducerRequestPurgatory.PurgatorySize",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -231,14 +261,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"FetchRequestPurgatory\",name=\"NumDelayedRequests\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.FetchRequestPurgatory.NumDelayedRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -246,14 +278,16 @@
         },
         {
           "obj": "\"kafka.server\":type=\"FetchRequestPurgatory\",name=\"PurgatorySize\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.server.FetchRequestPurgatory.PurgatorySize",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -261,14 +295,16 @@
         },
         {
           "obj": "\"kafka.network\":type=\"RequestMetrics\",name=\"Produce-RequestsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.network.RequestMetrics.ProduceRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -276,14 +312,16 @@
         },
         {
           "obj": "\"kafka.network\":type=\"RequestMetrics\",name=\"Fetch-Follower-RequestsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.network.RequestMetrics.FetchFollowerRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -291,14 +329,16 @@
         },
         {
           "obj": "\"kafka.network\":type=\"RequestMetrics\",name=\"Fetch-Consumer-RequestsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.network.RequestMetrics.FetchConsumerRequests",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -306,14 +346,16 @@
         },
         {
           "obj": "\"kafka.controller\":type=\"KafkaController\",name=\"ActiveControllerCount\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.controller.KafkaController.ActiveControllerCount",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -321,14 +363,16 @@
         },
         {
           "obj": "\"kafka.controller\":type=\"KafkaController\",name=\"OfflinePartitionsCount\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.controller.KafkaController.OfflinePartitionsCount",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -336,14 +380,16 @@
         },
         {
           "obj": "\"kafka.controller\":type=\"ControllerStats\",name=\"LeaderElectionRateAndTimeMs\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.controller.ControllerStats.LeaderElection",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -351,14 +397,16 @@
         },
         {
           "obj": "\"kafka.controller\":type=\"ControllerStats\",name=\"UncleanLeaderElectionsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.controller.ControllerStats.UncleanLeaderElection",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -366,14 +414,16 @@
         },
         {
           "obj": "\"kafka.consumer\":type=\"ConsumerFetcherManager\",name=\"*-MaxLag\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.consumer.ConsumerFetcherManager.MaxLag",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -381,14 +431,16 @@
         },
         {
           "obj": "\"kafka.consumer\":type=\"ConsumerFetcherManager\",name=\"*-MinFetchRate\"",
-          "attr": [ "Value" ],
+          "attr": [
+            "Value"
+          ],
           "resultAlias": "sdkafka.consumer.ConsumerFetcherManager.MinFetchRate",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -396,14 +448,16 @@
         },
         {
           "obj": "\"kafka.producer\":type=\"ProducerRequestsMetrics\",name=\"-AllBrokersProducerRequestSize\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.producer.ProducerRequestsMetrics.AllBrokersProducerRequestSize",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -411,14 +465,16 @@
         },
         {
           "obj": "\"kafka.producer\":type=\"ProducerRequestsMetrics\",name=\"-AllBrokersProducerRequestRateAndTimeMs\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.producer.ProducerRequestsMetrics.AllBrokersProducerRequestRate",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -426,14 +482,16 @@
         },
         {
           "obj": "\"kafka.producer\":type=\"ProducerStats\",name=\"-FailedSendsPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.producer.ProducerStats.FailedSendsPerSec",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -441,14 +499,16 @@
         },
         {
           "obj": "\"kafka.producer\":type=\"ProducerTopicMetrics\",name=\"-AllTopicsBytesPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.producer.ProducerTopicMetrics.AllTopicsBytes",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -456,14 +516,16 @@
         },
         {
           "obj": "\"kafka.producer\":type=\"ProducerTopicMetrics\",name=\"-AllTopicsDroppedMessagesPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.producer.ProducerTopicMetrics.AllTopicsDroppedMessages",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }
@@ -471,14 +533,16 @@
         },
         {
           "obj": "\"kafka.producer\":type=\"ProducerTopicMetrics\",name=\"-AllTopicsMessagesPerSec\"",
-          "attr": [ "Count" ],
+          "attr": [
+            "Count"
+          ],
           "resultAlias": "sdkafka.producer.ProducerTopicMetrics.AllTopicsMessages",
           "outputWriters": [
             {
               "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
               "settings": {
                 "token": "STACKDRIVER_API_KEY",
-                "url":"https://jmx-gateway.stackdriver.com/v1/custom",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
                 "source": "AWS_INSTANCE_ID"
               }
             }

--- a/jmxtrans/stackdriver/json-specify-instance/tomcat-7.json
+++ b/jmxtrans/stackdriver/json-specify-instance/tomcat-7.json
@@ -1,86 +1,86 @@
 {
-   "servers":[
-      {
-         "port":"TOMCAT_JMX_PORT",
-         "host":"TOMCAT_JMX_HOST",
-         "queries":[
+  "servers": [
+    {
+      "port": "TOMCAT_JMX_PORT",
+      "host": "TOMCAT_JMX_HOST",
+      "numQueryThreads": 2,
+      "queries": [
+        {
+          "obj": "Catalina:type=ThreadPool,name=*",
+          "attr": [
+            "currentThreadCount",
+            "currentThreadsBusy",
+            ""
+          ],
+          "resultAlias": "tomcat.connectors",
+          "outputWriters": [
             {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-                "obj": "Catalina:type=ThreadPool,name=*",
-            	"resultAlias": "tomcat.connectors",
-            	"attr": [
-                	"currentThreadCount",
-                	"currentThreadsBusy", 
-                	""
-            	]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-                "obj": "Catalina:type=Manager,context=*,host=*",
-            	"resultAlias": "tomcat.manager",
-            	"attr": [
-                	"activeSessions"
-            	]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-                "obj": "Catalina:type=GlobalRequestProcessor,name=*",
-            	"resultAlias": "tomcat.requestProcessor",
-            	"attr": [
-                	"bytesReceived",
-                	"bytesSent",
-                	"errorCount",
-                	"processingTime",
-                	"requestCount"
-            	]
-            },
-            {
-               "outputWriters":[
-                  {
-                     "@class":"com.googlecode.jmxtrans.model.output.StackdriverWriter",
-                     "settings":{
-                        "token":"STACKDRIVER_API_KEY",
-                        "url":"https://jmx-gateway.stackdriver.com/v1/custom",
-                        "source": "AWS_INSTANCE_ID"
-                     }
-                  }
-               ],
-                "obj": "Catalina:type=DataSource,context=*,host=*,class=javax.sql.DataSource,name=*",
-            	"resultAlias": "tomcat.data-source",
-            	"attr": [
-                	"numActive",
-                	"numIdle"
-            	]
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
             }
-         ],
-         "numQueryThreads":2
-      }
-   ]
+          ]
+        },
+        {
+          "obj": "Catalina:type=Manager,context=*,host=*",
+          "attr": [
+            "activeSessions"
+          ],
+          "resultAlias": "tomcat.manager",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "Catalina:type=GlobalRequestProcessor,name=*",
+          "attr": [
+            "bytesReceived",
+            "bytesSent",
+            "errorCount",
+            "processingTime",
+            "requestCount"
+          ],
+          "resultAlias": "tomcat.requestProcessor",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        },
+        {
+          "obj": "Catalina:type=DataSource,context=*,host=*,class=javax.sql.DataSource,name=*",
+          "attr": [
+            "numActive",
+            "numIdle"
+          ],
+          "resultAlias": "tomcat.data-source",
+          "outputWriters": [
+            {
+              "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+              "settings": {
+                "token": "STACKDRIVER_API_KEY",
+                "url": "https://jmx-gateway.stackdriver.com/v1/custom",
+                "source": "AWS_INSTANCE_ID"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/jmxtrans/templates/activemq_v5.8_basic.json.tmpl
+++ b/jmxtrans/templates/activemq_v5.8_basic.json.tmpl
@@ -1,0 +1,33 @@
+{
+  "serverInfo": {
+    "host": "ACTIVEMQ_JMX_HOST",
+    "port": "ACTIVEMQ_JMX_PORT",
+    "numQueryThreads": 2
+  },
+  "queryInfos": [
+    {
+      "obj": "org.apache.activemq:type=Broker,brokerName=localhost",
+      "resultAlias": "sdamq.broker",
+      "attr": [
+        "AverageMessageSize",
+        "CurrentConnectionsCount",
+        "JobSchedulerStoreLimit",
+        "JobSchedulerStorePercentUsage",
+        "MaxMessageSize",
+        "MemoryLimit",
+        "MemoryPercentUsage",
+        "MinMessageSize",
+        "StoreLimit",
+        "StorePercentUsage",
+        "TempLimit",
+        "TempPercentUsage",
+        "TotalConnectionsCount",
+        "TotalConsumerCount",
+        "TotalDequeueCount",
+        "TotalEnqueueCount",
+        "TotalMessageCount",
+        "TotalProducerCount"
+      ]
+    }
+  ]
+}

--- a/jmxtrans/templates/activemq_v5.8_expanded.json.tmpl
+++ b/jmxtrans/templates/activemq_v5.8_expanded.json.tmpl
@@ -1,0 +1,64 @@
+{
+  "serverInfo": {
+    "host": "ACTIVEMQ_JMX_HOST",
+    "port": "ACTIVEMQ_JMX_PORT",
+    "numQueryThreads": 2
+  },
+  "queryInfos": [
+    {
+      "obj": "org.apache.activemq:type=Broker,brokerName=localhost",
+      "resultAlias": "sdamq.broker",
+      "attr": [
+        "AverageMessageSize",
+        "CurrentConnectionsCount",
+        "JobSchedulerStoreLimit",
+        "JobSchedulerStorePercentUsage",
+        "MaxMessageSize",
+        "MemoryLimit",
+        "MemoryPercentUsage",
+        "MinMessageSize",
+        "StoreLimit",
+        "StorePercentUsage",
+        "TempLimit",
+        "TempPercentUsage",
+        "TotalConnectionsCount",
+        "TotalConsumerCount",
+        "TotalDequeueCount",
+        "TotalEnqueueCount",
+        "TotalMessageCount",
+        "TotalProducerCount"
+      ]
+    },
+    {
+      "obj": "org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Topic,destinationName=*",
+      "resultAlias": "activemq.topic",
+      "attr": [
+        "ConsumerCount",
+        "ProducerCount",
+        "EnqueueCount",
+        "DequeueCount",
+        "InFlightCount",
+        "ExpiredCount"
+      ],
+      "typeNames": [
+        "destinationName"
+      ]
+    },
+    {
+      "obj": "org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Queue,destinationName=*",
+      "resultAlias": "activemq.queue",
+      "attr": [
+        "ConsumerCount",
+        "ProducerCount",
+        "QueueSize",
+        "EnqueueCount",
+        "DequeueCount",
+        "InFlightCount",
+        "ExpiredCount"
+      ],
+      "typeNames": [
+        "destinationName"
+      ]
+    }
+  ]
+}

--- a/jmxtrans/templates/cassandra-06.json.tmpl
+++ b/jmxtrans/templates/cassandra-06.json.tmpl
@@ -1,0 +1,184 @@
+{
+  "serverInfo": {
+    "port": "7199",
+    "host": "localhost",
+    "numQueryThreads": 2
+  },
+  "queryInfos": [
+    {
+      "obj": "org.apache.cassandra.db:type=StorageService",
+      "resultAlias": "cassandra.storageservice",
+      "attr": [
+        "Load",
+        "ExceptionCount"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.db:type=Commitlog",
+      "resultAlias": "cassandra.commitlog",
+      "attr": [
+        "CompletedTasks",
+        "PendingTasks",
+        "TotalCommitlogSize"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.db:type=CompactionManager",
+      "resultAlias": "cassandra.compactionmanager",
+      "attr": [
+        "PendingTasks",
+        "CompletedTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.concurrent:type=ROW-MUTATION-STAGE",
+      "resultAlias": "cassandra.stage.MutationStage",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.concurrent:type=CONSISTENCY-MANAGER",
+      "resultAlias": "cassandra.stage.ReadRepairStage",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.concurrent:type=ROW-READ-STAGE",
+      "resultAlias": "cassandra.stage.ReadStage",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.request:type=ReplicateOnWriteStage",
+      "resultAlias": "cassandra.stage.ReplicateOnWriteStage",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.concurrent:type=RESPONSE-STAGE",
+      "resultAlias": "cassandra.stage.RequestResponseStage",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.internal:type=AntiEntropySessions",
+      "resultAlias": "cassandra.internal.AntiEntropySessions",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.internal:type=AntiEntropyStage",
+      "resultAlias": "cassandra.internal.AntiEntropyStage",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.internal:type=FlushWriter",
+      "resultAlias": "cassandra.internal.FlushWriter",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.internal:type=GossipStage",
+      "resultAlias": "cassandra.internal.GossipStage",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.internal:type=HintedHandoff",
+      "resultAlias": "cassandra.internal.HintedHandoff",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.internal:type=InternalResponseStage",
+      "resultAlias": "cassandra.internal.InternalResponseStage",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.internal:type=MemtablePostFlusher",
+      "resultAlias": "cassandra.internal.MemtablePostFlusher",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.internal:type=MigrationStage",
+      "resultAlias": "cassandra.internal.MigrationStage",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.internal:type=MiscStage",
+      "resultAlias": "cassandra.internal.MiscStage",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.internal:type=StreamStage",
+      "resultAlias": "cassandra.internal.StreamStage",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    }
+  ]
+}

--- a/jmxtrans/templates/cassandra.json.tmpl
+++ b/jmxtrans/templates/cassandra.json.tmpl
@@ -1,0 +1,194 @@
+{
+  "serverInfo": {
+    "port": "CASSANDRA_PORT",
+    "host": "CASSANDRA_HOST",
+    "numQueryThreads": 2
+  },
+  "queryInfos": [
+    {
+      "obj": "org.apache.cassandra.db:type=StorageService",
+      "resultAlias": "cassandra.storageservice",
+      "attr": [
+        "Load",
+        "ExceptionCount"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.db:type=Commitlog",
+      "resultAlias": "cassandra.commitlog",
+      "attr": [
+        "CompletedTasks",
+        "PendingTasks",
+        "TotalCommitlogSize"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.db:type=CompactionManager",
+      "resultAlias": "cassandra.compactionmanager",
+      "attr": [
+        "PendingTasks",
+        "CompletedTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.request:type=MutationStage",
+      "resultAlias": "cassandra.stage.MutationStage",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.request:type=ReadRepairStage",
+      "resultAlias": "cassandra.stage.ReadRepairStage",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.request:type=ReadStage",
+      "resultAlias": "cassandra.stage.ReadStage",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.request:type=ReplicateOnWriteStage",
+      "resultAlias": "cassandra.stage.ReplicateOnWriteStage",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.request:type=RequestResponseStage",
+      "resultAlias": "cassandra.stage.RequestResponseStage",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.internal:type=AntiEntropySessions",
+      "resultAlias": "cassandra.internal.AntiEntropySessions",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.internal:type=AntiEntropyStage",
+      "resultAlias": "cassandra.internal.AntiEntropyStage",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.internal:type=FlushWriter",
+      "resultAlias": "cassandra.internal.FlushWriter",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.internal:type=GossipStage",
+      "resultAlias": "cassandra.internal.GossipStage",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.internal:type=HintedHandoff",
+      "resultAlias": "cassandra.internal.HintedHandoff",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.internal:type=InternalResponseStage",
+      "resultAlias": "cassandra.internal.InternalResponseStage",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.internal:type=MemtablePostFlusher",
+      "resultAlias": "cassandra.internal.MemtablePostFlusher",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.internal:type=MigrationStage",
+      "resultAlias": "cassandra.internal.MigrationStage",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.internal:type=MiscStage",
+      "resultAlias": "cassandra.internal.MiscStage",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.internal:type=StreamStage",
+      "resultAlias": "cassandra.internal.StreamStage",
+      "attr": [
+        "ActiveCount",
+        "CompletedTasks",
+        "CurrentlyBlockedTasks",
+        "PendingTasks"
+      ]
+    },
+    {
+      "obj": "org.apache.cassandra.db:type=StorageProxy",
+      "resultAlias": "cassandra.internal.StorageProxy",
+      "attr": [
+        "RecentReadLatencyMicros",
+        "RecentWriteLatencyMicros",
+        "RecentRangeLatencyMicros",
+        "HintsInProgress"
+      ]
+    }
+  ]
+}

--- a/jmxtrans/templates/create_templates.py
+++ b/jmxtrans/templates/create_templates.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+import json
+import sys
+from collections import OrderedDict
+
+def main(fileNames):
+    for filename in fileNames:
+        with open(filename) as in_file:
+            orig = json.load(in_file, object_pairs_hook=OrderedDict)
+
+        server = orig["servers"][0]
+        queries = server["queries"]
+        del server["queries"]
+
+        # server is now our serverInfo
+        result = OrderedDict()
+        result["serverInfo"] = server
+
+        for query in queries:
+            settings = query['outputWriters'][0]['settings']
+            del query["outputWriters"]
+            if 'typeNames' in settings:
+                query['typeNames'] = settings['typeNames']
+
+        # keep the other properties in "server"
+        result["queryInfos"] = queries
+
+        with open(filename + '.tmpl', 'w') as out:
+            json.dump(result, out, separators=(',', ': '), indent=2)
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/jmxtrans/templates/custom.json.tmpl
+++ b/jmxtrans/templates/custom.json.tmpl
@@ -1,0 +1,25 @@
+{
+  "serverInfo": {
+    "port": "JMX PORT",
+    "host": "localhost",
+    "numQueryThreads": 2
+  },
+  "queryInfos": [
+    {
+      "obj": "MBEAN PATH",
+      "resultAlias": "MYAPP.MYSUBYSTEM.PREFIX",
+      "attr": [
+        "MBEAN ATTRIBUTE 1",
+        "MBEAN ATTRIBUTE 2",
+        "MBEAN ATTRIBUTE 3"
+      ]
+    },
+    {
+      "obj": "MBEAN 2 PATH",
+      "resultAlias": "MYAPP.MYSUBYSTEM.PREFIX",
+      "attr": [
+        "MBEAN ATTRIBUTE"
+      ]
+    }
+  ]
+}

--- a/jmxtrans/templates/differ.py
+++ b/jmxtrans/templates/differ.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+
+from collections import OrderedDict
+import json
+import sys
+
+def diff(obj1, obj2):
+  """Prints a simple human-readable difference between two Python objects."""
+  result = []
+  diffAny(obj1, obj2, result)
+  return '\n'.join(result)
+
+def diffAny(obj1, obj2, result):
+    """Recursively calculate the difference between 'obj1' and 'obj2' and
+    append human-readable descriptions of those differences to the 'result'
+    array.
+"""
+    if (type(obj1) is not type(obj2)):
+        result.append("Types differ: {0} vs {1} ({2} vs {3})".format(
+            str(type(obj1)), str(type(obj2)), obj1, obj2))
+        return
+
+    t = type(obj1)
+
+    if (t is list):
+        diffList(obj1, obj2, result)
+        return
+
+    if (t is dict or t is OrderedDict):
+        diffDict(obj1, obj2, result)
+        return
+
+    if (obj1 != obj2):
+        result.append("Values differ: {0} vs {1}".format(obj1, obj2))
+
+
+def diffList(list1, list2, result):
+    """Helper method that handles lists""".
+    if (len(list1) != len(list2)):
+        result.append("List lengths differ: {0} vs {1}".format(
+          len(list1), len(list2)))
+
+    # Compare the corresponding items in the lists (stop at the end of the
+    # shorter list if one is shorter than the other)
+    for pair in zip(list1, list2):
+        diffAny(pair[0], pair[1], result)
+
+
+def diffDict(dict1, dict2, result):
+    """Helper method that handles dictionaries""".
+    if (len(dict1) != len(dict2)):
+        result.append("Dict lengths differ: {0} vs {1}".format(
+          len(dict1), len(dict2)))
+    for (key1, value1) in dict1.items():
+        if key1 in dict2:
+            value2 = dict2[key1]
+            diffAny(value1, value2, result)
+
+    diffDictHelper("only in dict1", dict1, dict2, result)
+    diffDictHelper("only in dict2", dict2, dict1, result)
+
+def diffDictHelper(text, dict1, dict2, result):
+    """Another helper method that describes keys present in dict1 that are
+    absent from dict2."""
+    for key1 in dict1:
+        if key1 not in dict2:
+            result.append("{0}: {1}".format(text, key1))

--- a/jmxtrans/templates/differences.txt
+++ b/jmxtrans/templates/differences.txt
@@ -1,0 +1,121 @@
+Differences for ../stackdriver/json-specify-instance/activemq_v5.8_basic.json:
+Values differ: INSTANCE_ID vs AWS_INSTANCE_ID
+
+Differences for ../google-cloud-monitoring/json-specify-instance/activemq_v5.8_basic.json:
+Values differ: INSTANCE_ID vs GCE_INSTANCE_ID
+
+Differences for ../stackdriver/json-specify-instance/activemq_v5.8_expanded.json:
+Values differ: INSTANCE_ID vs AWS_INSTANCE_ID
+Values differ: INSTANCE_ID vs AWS_INSTANCE_ID
+Values differ: INSTANCE_ID vs AWS_INSTANCE_ID
+
+Differences for ../google-cloud-monitoring/json-specify-instance/activemq_v5.8_expanded.json:
+Values differ: INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: INSTANCE_ID vs GCE_INSTANCE_ID
+
+Differences for ../stackdriver/json-specify-instance/cassandra-06.json:
+Dict lengths differ: 0 vs 1
+only in dict2: servers
+
+Differences for ../google-cloud-monitoring/json-specify-instance/cassandra-06.json:
+Dict lengths differ: 0 vs 1
+only in dict2: servers
+
+Differences for ../stackdriver/json-detect-instance/cassandra.json:
+Values differ: 7199 vs CASSANDRA_PORT
+Values differ: localhost vs CASSANDRA_HOST
+
+Differences for ../google-cloud-monitoring/json-detect-instance/cassandra.json:
+Values differ: 7199 vs CASSANDRA_PORT
+Values differ: localhost vs CASSANDRA_HOST
+
+Differences for ../google-cloud-monitoring/json-specify-instance/cassandra.json:
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+
+Differences for ../google-cloud-monitoring/json-specify-instance/custom.json:
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+
+Differences for ../google-cloud-monitoring/json-specify-instance/hbase_thrift.json:
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+
+Differences for ../google-cloud-monitoring/json-specify-instance/hbase_v0.95.json:
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+
+Differences for ../google-cloud-monitoring/json-specify-instance/hbase_v0.98.json:
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+
+Differences for ../google-cloud-monitoring/json-specify-instance/jboss.json:
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+
+Differences for ../google-cloud-monitoring/json-specify-instance/jvm-sun-hotspot.json:
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+
+Differences for ../google-cloud-monitoring/json-specify-instance/kafka.json:
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+
+Differences for ../google-cloud-monitoring/json-specify-instance/tomcat-7.json:
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+Values differ: AWS_INSTANCE_ID vs GCE_INSTANCE_ID
+

--- a/jmxtrans/templates/generate-json-files-from-templates.py
+++ b/jmxtrans/templates/generate-json-files-from-templates.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python
+
+from collections import OrderedDict
+import copy
+import json
+import os
+import sys
+
+import differ
+
+def transform(template, url, source, detectInstance):
+    """Transform 'template' into a data structure suitable for consumption by
+    jmxtrans.
+
+    This method transforms the 'template' object into the expected output
+    format by changing the data structure and substituting 'url', 'source',
+    and 'detectInstance' at the appropriate locations.
+
+    The method is parameterized in this way because the program generates
+    four different output files, each parameterized in a slightly different way.
+    See the doc comments for the 'main' for more information.
+
+    ARGUMENTS:
+
+    template - The input data structure. Its type is described below.
+
+    url - The Gateway string to be embedded in the output (this is either the
+          Stackdriver or the Google gateway).
+
+    source - The "source" property of the settingsDict (this is either the
+             string "AWS_INSTANCE_ID" or "GCE_INSTANCE_ID". Note that these
+             strings are themselves placeholders, as the human being ultimately
+             consuming these JSON files is expected to put something there.
+
+    detectInstance - The "detectInstance" property of the settingsDict (this is
+        either the string "AWS" or the string "GCE").
+
+    Exactly one of 'source' and 'detectInstance' will be None.
+
+    'template' is expected to have the following dictionary type:
+    {
+        "serverInfo": ServerInfo,
+        "queryInfos": [ QueryInfo, ... ]  # One or more QueryInfos
+    }
+
+    The 'ServerInfo' type is defined as the following dictionary type:
+    {
+        # ServerInfo properties. The contents of serverInfo are opaque to
+        # this program and can therefore be arbitrary. However in practice
+        # the properties currently used in all of our cases are:
+        "port": Number
+        "host": String
+        "numQueryThreads": Number
+    },
+
+    The 'QueryInfo' type is defined as the following dictionary type:
+    {
+        # Bean name, e.g. "jboss.web:type=ThreadPool,name=*".
+        "obj": String
+
+        # Alias used by upstream processing, e.g. "jboss.threads".
+        "resultAlias": String
+
+        # Array of JMX attributes, e.g.:
+        # [ "currentThreadCount","currentThreadsBusy" ]
+        "attr": [Attribute, ...]
+
+        # Optional JMX typeNames array:
+        # e.g. "typeNames": [ "name" ]
+        "typeNames"?: [String,...]
+    },
+
+
+    RESULT:
+
+    The result produced is a dictionary type in the following format:
+    {
+        "servers": [Server]  # Always only one Server
+    }
+
+    'Server' is a dictionary type in the following format:
+    {
+        # All properties copied over from template["serverInfo"], defined above.
+        # Plus, an additional property called "queries", an array of Query.
+        "queries": [ Query, ...]
+    }
+
+    'Query' is a dictionary type in the following format:
+    {
+        # The values for these three properties are copied directly from the
+        # corresponding place in the 'template' object.
+        "obj": String,  # JMX object
+        "resultAlias": String,
+        "attr": [String,...],  # attributes
+
+        # There is one more property whose type is defined below.
+        "outputWriters": [OutputWriter]  # A single OutputWriter
+    }
+
+    'OutputWriter' is a dictionary type in the following format:
+    {
+        "@class": "com.googlecode.jmxtrans.model.output.StackdriverWriter",
+        "settings": Settings
+    }
+
+    'Settings' is a dictionary type in the following format
+    {
+        "token": "STACKDRIVER_API_KEY",
+
+        # The value of "url" comes from the 'url' argument to this method.
+        "url": String,
+
+        # The value of the (optional) "detectInstance" property comes from the
+        # 'detectInstance' argument to this method.
+        "detectInstance"?: String,
+
+        # The value of the (optional) "source" property comes from the 'source'
+        # argument to this method.
+        "source"?: String,
+
+        # The value of the (optional) "typeNames" property comes from the
+        # QueryInfo.typeNames property above.
+        "typeNames"?: [String, ...]
+    }
+"""
+
+    assert len(template) == 2, (
+        "Dictionary has {0} keys, expected 2.".format(len(template)))
+    serverInfo = template["serverInfo"]
+    queryInfos = template["queryInfos"]
+
+    queries = []
+    for qi in queryInfos:
+        # First check for unexpected properties.
+        expectedProperties = {"obj", "resultAlias", "attr", "typeNames"}
+        for key in qi:
+            if key not in expectedProperties:
+                raise ValueError(
+                    "Unexpected key " + key + " found in queryInfos")
+
+        # There are three required entries and one optional one.
+        obj = qi["obj"]
+        attr = qi["attr"]
+        resultAlias = qi["resultAlias"]
+        typeNames = qi["typeNames"] if "typeNames" in qi else None
+
+        # Build the query element that we are outputting, starting with the
+        # nested settingsDict.
+        settingsDict = OrderedDict()
+        settingsDict["token"] = u"STACKDRIVER_API_KEY"
+        settingsDict["url"] = url
+        if source is not None:
+            settingsDict["source"] = source
+        if detectInstance is not None:
+            settingsDict["detectInstance"] = detectInstance
+        if typeNames is not None:
+            settingsDict["typeNames"] = typeNames
+
+        # Next, go out one level and build the outputWriters array, which always
+        # contains a single outputWriterDict.
+        outputWriterDict = OrderedDict()
+        outputWriterDict["@class"] = (
+            u"com.googlecode.jmxtrans.model.output.StackdriverWriter")
+        outputWriterDict["settings"] = settingsDict
+        outputWriters = [outputWriterDict]
+
+        # Finally go out one more level and build the query element, which
+        # contains (obj, attr, resultAlias, and outputWriters)
+        query = OrderedDict()
+        query["obj"] = obj
+        query["attr"] = attr
+        query["resultAlias"] = resultAlias
+        query["outputWriters"] = outputWriters
+        queries.append(query)
+
+    # Now build the serverDict which has all the properties of serverInfo, plus
+    # the queries array.
+    serverDict = copy.deepcopy(serverInfo)
+    serverDict["queries"] = queries
+    servers = [serverDict]
+
+    # Finally, build the result.
+    result = OrderedDict()
+    result["servers"] = servers
+    return result
+
+
+def write_config_file(template, output_file, url, source, detectInstance):
+    """Write the configuration file.
+
+    1. Use the 'transform' method to transform 'template' into the output
+       format.
+    2. Load the previously-existing data (if any) from 'output_file'.
+    3. Write the new data (the result of 'transform') to 'output_file'.
+    4. Print a human-readable summary of the differences between #2 and #3.
+"""
+
+    transformed = transform(template, url, source, detectInstance)
+
+    # If a file exists at 'output_file', read it in so we can show the
+    # differences (as a sanity check).
+    original = OrderedDict()
+    if (os.path.isfile(output_file)):
+        with open(output_file) as orig:
+            original = json.load(orig, object_pairs_hook=OrderedDict)
+
+    # Write the file!
+    with open(output_file, 'w') as out:
+        json.dump(transformed, out, indent=2, separators=(',', ': '))
+
+    # Explain the differences (as a sanity check).
+    differences = differ.diff(original, transformed)
+    if (len(differences)):
+        print "Differences for {0}:\n{1}\n".format(output_file, differences)
+
+
+def write_readme_file(output_dir):
+    """Write a simple README file to the output directory.
+
+    This reminds future maintainers that the output files are automatically
+    generated and should not be generated directly.
+"""
+    with open(output_dir + 'README', 'w') as out:
+        out.write('The files in this directory are automatically generated' +
+                  ' and will be overwritten.\n')
+        out.write('If you want to change them, please see\n')
+        out.write('../../templates/generate-json-files-from-templates.py\n')
+        out.write('and edit the .json.tmpl files in that directory.\n')
+
+
+def main(fileNames):
+    """For each FOO.json.tmpl in fileNames, write four FOO.json files in the
+    appropriate output directories. Also write (the same) README file in
+    each output directory.
+
+    The four files can perhaps best be understood as the following matrix:
+
+                       detect                        specify
+        +--------------------------------+-------------------------------+
+        | gw = "https://jmx-gateway.stackdriver.com/v1/custom"           |
+Stack-  | dir = "../stackdriver/" + subdir                               |
+driver  |                                                                |
+        | subdir = json-detect-instance | subdir = json-specify-instance |
+        | detectInstance = AWS          | source = AWS_INSTANCE_ID       |
+        +----------------------------------------------------------------+
+        | gw = https://jmx-gateway.google.stackdriver.com/v1/custom      |
+Google  | dir = "../google-cloud-monitoring/" + subdir                   |
+        |                                                                |
+        | subdir = json-detect-instance | subdir = json-specify-instance |
+        | detectInstance: GCE           | source: GCE_INSTANCE_ID        |
+        +--------------------------------+-------------------------------+
+"""
+
+    # Stackdriver gateway and Google gateway.
+    sd_gw = u'https://jmx-gateway.stackdriver.com/v1/custom'
+    gg_gw = u'https://jmx-gateway.google.stackdriver.com/v1/custom'
+
+    # The four output directories
+    sd_jdi = '../stackdriver/json-detect-instance/'
+    sd_jsi = '../stackdriver/json-specify-instance/'
+    gg_jdi = '../google-cloud-monitoring/json-detect-instance/'
+    gg_jsi = '../google-cloud-monitoring/json-specify-instance/'
+
+    for infile in fileNames:
+        assert infile.endswith('.json.tmpl')
+        outfile = infile[:-5]  # strip off '.tmpl'
+
+        with open(infile) as input:
+            template = json.load(input, object_pairs_hook=OrderedDict)
+
+        # Two Stackdriver files.
+        write_config_file(template, sd_jdi + outfile,
+                          sd_gw, None, u'AWS')
+        write_config_file(template, sd_jsi + outfile,
+                          sd_gw, u'AWS_INSTANCE_ID', None)
+        # Two Google files.
+        write_config_file(template, gg_jdi + outfile,
+                          gg_gw, None, u'GCE')
+        write_config_file(template, gg_jsi + outfile,
+                          gg_gw, u'GCE_INSTANCE_ID', None)
+
+    # Two Stackdriver READMEs.
+    write_readme_file(sd_jdi)
+    write_readme_file(sd_jsi)
+    # Two Google READMEs.
+    write_readme_file(gg_jdi)
+    write_readme_file(gg_jsi)
+
+
+# Usage:
+#   cd jmxtrans/templates
+#   ./generate-json-files-from-templates.py *.tmpl
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/jmxtrans/templates/hbase_thrift.json.tmpl
+++ b/jmxtrans/templates/hbase_thrift.json.tmpl
@@ -1,0 +1,33 @@
+{
+  "serverInfo": {
+    "port": "HBASE_THRIFT_JMX_PORT",
+    "host": "HBASE_THRIFT_JMX_HOST",
+    "numQueryThreads": 2
+  },
+  "queryInfos": [
+    {
+      "obj": "Hadoop:service=HBase,name=Thrift,sub=ThriftOne",
+      "attr": [
+        "callQueueLen",
+        "SlowThriftCall_mean",
+        "TimeInQueue_mean",
+        "ThriftCall_mean",
+        "BatchGet_mean",
+        "BatchMutate_mean"
+      ],
+      "resultAlias": "sdhbase.Thrift.ThriftOne"
+    },
+    {
+      "obj": "Hadoop:service=HBase,name=Thrift,sub=ThriftTwo",
+      "attr": [
+        "callQueueLen",
+        "SlowThriftCall_mean",
+        "TimeInQueue_mean",
+        "ThriftCall_mean",
+        "BatchGet_mean",
+        "BatchMutate_mean"
+      ],
+      "resultAlias": "sdhbase.Thrift.ThriftTwo"
+    }
+  ]
+}

--- a/jmxtrans/templates/hbase_v0.95.json.tmpl
+++ b/jmxtrans/templates/hbase_v0.95.json.tmpl
@@ -1,0 +1,41 @@
+{
+  "serverInfo": {
+    "port": "HBASE_JMX_PORT",
+    "host": "HBASE_JMX_HOST",
+    "numQueryThreads": 2
+  },
+  "queryInfos": [
+    {
+      "obj": "hadoop:service=RegionServer,name=RegionServerStatistics",
+      "attr": [
+        "blockCacheExpressCachingRatio",
+        "blockCacheHitCachingRatio",
+        "callQueueLength",
+        "compactionQueueLength",
+        "compactionQueueSize",
+        "flushQueueSize",
+        "hdfsBlocksLocalityIndex",
+        "memstoreSizeMB",
+        "numberOfOnlineRegions",
+        "readRequestsCount",
+        "slowHLogAppendCount",
+        "usedHeapMB",
+        "writeRequestsCount",
+        "blockCacheCount",
+        "blockCacheEvictedCount",
+        "blockCacheFreeMB",
+        "blockCacheHitCount",
+        "blockCacheMissCount",
+        "blockCacheSizeMB",
+        "fsPreadLatencyNumOps",
+        "fsReadLatencyNumOps",
+        "fsWriteLatencyNumOps",
+        "NumberOfStores",
+        "NumberOfStorefiles",
+        "requestsPerSecond",
+        "storeFileIndexSizeMB"
+      ],
+      "resultAlias": "sdhbase.RegionServer.RegionServerStatistics"
+    }
+  ]
+}

--- a/jmxtrans/templates/hbase_v0.98.json.tmpl
+++ b/jmxtrans/templates/hbase_v0.98.json.tmpl
@@ -1,0 +1,52 @@
+{
+  "serverInfo": {
+    "port": "HBASE_JMX_PORT",
+    "host": "HBASE_JMX_HOST",
+    "numQueryThreads": 3
+  },
+  "queryInfos": [
+    {
+      "obj": "Hadoop:service=HBase,name=Master,sub=Server",
+      "attr": [
+        "averageLoad",
+        "numRegionServers",
+        "numDeadRegionServers"
+      ],
+      "resultAlias": "sdhbase.Master.Server"
+    },
+    {
+      "obj": "Hadoop:service=HBase,name=IPC,sub=IPC",
+      "attr": [
+        "sentBytes",
+        "receivedBytes",
+        "queueSize",
+        "numOpenConnections"
+      ],
+      "resultAlias": "sdhbase.IPC.IPC"
+    },
+    {
+      "obj": "Hadoop:service=HBase,name=RegionServer,sub=Server",
+      "attr": [
+        "blockCacheCount",
+        "blockCacheEvictionCount",
+        "blockCacheFreeSize",
+        "blockCacheHitCount",
+        "blockCountHitPercent",
+        "blockCacheMissCount",
+        "blockCacheSize",
+        "compactionQueueLength",
+        "flushQueueLength",
+        "memStoreSize",
+        "storeCount",
+        "readRequestCount",
+        "storeFileIndexSize",
+        "writeRequestCount",
+        "totalRequestCount",
+        "slowAppendCount",
+        "slowPutCount",
+        "slowGetCount"
+      ],
+      "resultAlias": "sdhbase.RegionServer.RegionServerStatistics"
+    }
+  ]
+}

--- a/jmxtrans/templates/jboss.json.tmpl
+++ b/jmxtrans/templates/jboss.json.tmpl
@@ -1,0 +1,49 @@
+{
+  "serverInfo": {
+    "port": "8004",
+    "host": "localhost",
+    "numQueryThreads": 2
+  },
+  "queryInfos": [
+    {
+      "obj": "jboss.web:type=ThreadPool,name=*",
+      "resultAlias": "jboss.threads",
+      "attr": [
+        "currentThreadCount",
+        "currentThreadsBusy"
+      ],
+      "typeNames": [
+        "name"
+      ]
+    },
+    {
+      "obj": "jboss.web:type=GlobalRequestProcessor,name=*",
+      "resultAlias": "jboss.requests",
+      "attr": [
+        "bytesReceived",
+        "bytesSent",
+        "errorCount",
+        "maxTime",
+        "processingTime",
+        "requestCount"
+      ],
+      "typeNames": [
+        "name"
+      ]
+    },
+    {
+      "obj": "jboss.jca:service=ManagedConnectionPool,name=*",
+      "resultAlias": "jboss.datasources",
+      "attr": [
+        "ConnectionCount",
+        "ConnectionCreatedCount",
+        "InUseConnectionCount",
+        "MaxConnectionsInUseCount",
+        "AvailableConnectionCount"
+      ],
+      "typeNames": [
+        "name"
+      ]
+    }
+  ]
+}

--- a/jmxtrans/templates/jvm-sun-hotspot.json.tmpl
+++ b/jmxtrans/templates/jvm-sun-hotspot.json.tmpl
@@ -1,0 +1,53 @@
+{
+  "serverInfo": {
+    "port": "JMX_PORT",
+    "host": "JMX_HOST",
+    "numQueryThreads": 2
+  },
+  "queryInfos": [
+    {
+      "obj": "java.lang:type=Threading",
+      "resultAlias": "jvm.localhost.Threading",
+      "attr": [
+        "DaemonThreadCount",
+        "ThreadCount",
+        "PeakThreadCount"
+      ]
+    },
+    {
+      "obj": "java.lang:type=Memory",
+      "resultAlias": "jvm.localhost.Memory",
+      "attr": [
+        "HeapMemoryUsage",
+        "NonHeapMemoryUsage"
+      ]
+    },
+    {
+      "obj": "java.lang:type=Runtime",
+      "resultAlias": "jvm.localhost.Runtime",
+      "attr": [
+        "Uptime"
+      ]
+    },
+    {
+      "obj": "java.lang:type=OperatingSystem",
+      "resultAlias": "jvm.localhost.os",
+      "attr": [
+        "CommittedVirtualMemorySize",
+        "FreePhysicalMemorySize",
+        "FreeSwapSpaceSize",
+        "OpenFileDescriptorCount",
+        "ProcessCpuTime",
+        "SystemLoadAverage"
+      ]
+    },
+    {
+      "obj": "java.lang:type=GarbageCollector,name=*",
+      "resultAlias": "jvm.localhost.gc",
+      "attr": [
+        "CollectionCount",
+        "CollectionTime"
+      ]
+    }
+  ]
+}

--- a/jmxtrans/templates/kafka.json.tmpl
+++ b/jmxtrans/templates/kafka.json.tmpl
@@ -1,0 +1,232 @@
+{
+  "serverInfo": {
+    "port": "KAFKA_JMX_PORT",
+    "host": "KAFKA_JMX_HOST"
+  },
+  "queryInfos": [
+    {
+      "obj": "\"kafka.log\":type=\"LogFlushStats\",name=\"LogFlushRateAndTimeMs\"",
+      "attr": [
+        "Count"
+      ],
+      "resultAlias": "sdkafka.log.LogFlushStats.LogFlush"
+    },
+    {
+      "obj": "\"kafka.server\":type=\"BrokerTopicMetrics\",name=\"AllTopicsBytesInPerSec\"",
+      "attr": [
+        "Count"
+      ],
+      "resultAlias": "sdkafka.server.BrokerTopicMetrics.AllTopicsBytesIn"
+    },
+    {
+      "obj": "\"kafka.server\":type=\"BrokerTopicMetrics\",name=\"AllTopicsFailedFetchRequestsPerSec\"",
+      "attr": [
+        "Count"
+      ],
+      "resultAlias": "sdkafka.server.BrokerTopicMetrics.AllTopicsFailedFetchRequests"
+    },
+    {
+      "obj": "\"kafka.server\":type=\"BrokerTopicMetrics\",name=\"AllTopicsFailedProduceRequestsPerSec\"",
+      "attr": [
+        "Count"
+      ],
+      "resultAlias": "sdkafka.server.BrokerTopicMetrics.AllTopicsFailedProduceRequests"
+    },
+    {
+      "obj": "\"kafka.server\":type=\"BrokerTopicMetrics\",name=\"AllTopicsMessagesInPerSec\"",
+      "attr": [
+        "Count"
+      ],
+      "resultAlias": "sdkafka.server.BrokerTopicMetrics.AllTopicsMessagesIn"
+    },
+    {
+      "obj": "\"kafka.server\":type=\"BrokerTopicMetrics\",name=\"AllTopicsBytesOutPerSec\"",
+      "attr": [
+        "Count"
+      ],
+      "resultAlias": "sdkafka.server.BrokerTopicMetrics.AllTopicsBytesOut"
+    },
+    {
+      "obj": "\"kafka.server\":type=\"ReplicaManager\",name=\"UnderReplicatedPartitions\"",
+      "attr": [
+        "Value"
+      ],
+      "resultAlias": "sdkafka.server.ReplicaManager.UnderReplicatedPartitions"
+    },
+    {
+      "obj": "\"kafka.server\":type=\"ReplicaManager\",name=\"PartitionCount\"",
+      "attr": [
+        "Value"
+      ],
+      "resultAlias": "sdkafka.server.ReplicaManager.PartitionCount"
+    },
+    {
+      "obj": "\"kafka.server\":type=\"ReplicaManager\",name=\"LeaderCount\"",
+      "attr": [
+        "Value"
+      ],
+      "resultAlias": "sdkafka.server.ReplicaManager.LeaderCount"
+    },
+    {
+      "obj": "\"kafka.server\":type=\"ReplicaManager\",name=\"ISRShrinksPerSec\"",
+      "attr": [
+        "Count"
+      ],
+      "resultAlias": "sdkafka.server.ReplicaManager.ISRShrinks"
+    },
+    {
+      "obj": "\"kafka.server\":type=\"ReplicaManager\",name=\"IsrExpandsPerSec\"",
+      "attr": [
+        "Count"
+      ],
+      "resultAlias": "sdkafka.server.ReplicaManager.ISRExpands"
+    },
+    {
+      "obj": "\"kafka.server\":type=\"ReplicaFetcherManager\",name=\"Replica-MaxLag\"",
+      "attr": [
+        "Value"
+      ],
+      "resultAlias": "sdkafka.server.ReplicaFetcherManager.MaxLag"
+    },
+    {
+      "obj": "\"kafka.server\":type=\"ReplicaFetcherManager\",name=\"Replica-MinFetchRate\"",
+      "attr": [
+        "Value"
+      ],
+      "resultAlias": "sdkafka.server.ReplicaFetcherManager.MinFetchRate"
+    },
+    {
+      "obj": "\"kafka.server\":type=\"ProducerRequestPurgatory\",name=\"NumDelayedRequests\"",
+      "attr": [
+        "Value"
+      ],
+      "resultAlias": "sdkafka.server.ProducerRequestPurgatory.NumDelayedRequests"
+    },
+    {
+      "obj": "\"kafka.server\":type=\"ProducerRequestPurgatory\",name=\"PurgatorySize\"",
+      "attr": [
+        "Value"
+      ],
+      "resultAlias": "sdkafka.server.ProducerRequestPurgatory.PurgatorySize"
+    },
+    {
+      "obj": "\"kafka.server\":type=\"FetchRequestPurgatory\",name=\"NumDelayedRequests\"",
+      "attr": [
+        "Value"
+      ],
+      "resultAlias": "sdkafka.server.FetchRequestPurgatory.NumDelayedRequests"
+    },
+    {
+      "obj": "\"kafka.server\":type=\"FetchRequestPurgatory\",name=\"PurgatorySize\"",
+      "attr": [
+        "Value"
+      ],
+      "resultAlias": "sdkafka.server.FetchRequestPurgatory.PurgatorySize"
+    },
+    {
+      "obj": "\"kafka.network\":type=\"RequestMetrics\",name=\"Produce-RequestsPerSec\"",
+      "attr": [
+        "Count"
+      ],
+      "resultAlias": "sdkafka.network.RequestMetrics.ProduceRequests"
+    },
+    {
+      "obj": "\"kafka.network\":type=\"RequestMetrics\",name=\"Fetch-Follower-RequestsPerSec\"",
+      "attr": [
+        "Count"
+      ],
+      "resultAlias": "sdkafka.network.RequestMetrics.FetchFollowerRequests"
+    },
+    {
+      "obj": "\"kafka.network\":type=\"RequestMetrics\",name=\"Fetch-Consumer-RequestsPerSec\"",
+      "attr": [
+        "Count"
+      ],
+      "resultAlias": "sdkafka.network.RequestMetrics.FetchConsumerRequests"
+    },
+    {
+      "obj": "\"kafka.controller\":type=\"KafkaController\",name=\"ActiveControllerCount\"",
+      "attr": [
+        "Value"
+      ],
+      "resultAlias": "sdkafka.controller.KafkaController.ActiveControllerCount"
+    },
+    {
+      "obj": "\"kafka.controller\":type=\"KafkaController\",name=\"OfflinePartitionsCount\"",
+      "attr": [
+        "Value"
+      ],
+      "resultAlias": "sdkafka.controller.KafkaController.OfflinePartitionsCount"
+    },
+    {
+      "obj": "\"kafka.controller\":type=\"ControllerStats\",name=\"LeaderElectionRateAndTimeMs\"",
+      "attr": [
+        "Count"
+      ],
+      "resultAlias": "sdkafka.controller.ControllerStats.LeaderElection"
+    },
+    {
+      "obj": "\"kafka.controller\":type=\"ControllerStats\",name=\"UncleanLeaderElectionsPerSec\"",
+      "attr": [
+        "Count"
+      ],
+      "resultAlias": "sdkafka.controller.ControllerStats.UncleanLeaderElection"
+    },
+    {
+      "obj": "\"kafka.consumer\":type=\"ConsumerFetcherManager\",name=\"*-MaxLag\"",
+      "attr": [
+        "Value"
+      ],
+      "resultAlias": "sdkafka.consumer.ConsumerFetcherManager.MaxLag"
+    },
+    {
+      "obj": "\"kafka.consumer\":type=\"ConsumerFetcherManager\",name=\"*-MinFetchRate\"",
+      "attr": [
+        "Value"
+      ],
+      "resultAlias": "sdkafka.consumer.ConsumerFetcherManager.MinFetchRate"
+    },
+    {
+      "obj": "\"kafka.producer\":type=\"ProducerRequestsMetrics\",name=\"-AllBrokersProducerRequestSize\"",
+      "attr": [
+        "Count"
+      ],
+      "resultAlias": "sdkafka.producer.ProducerRequestsMetrics.AllBrokersProducerRequestSize"
+    },
+    {
+      "obj": "\"kafka.producer\":type=\"ProducerRequestsMetrics\",name=\"-AllBrokersProducerRequestRateAndTimeMs\"",
+      "attr": [
+        "Count"
+      ],
+      "resultAlias": "sdkafka.producer.ProducerRequestsMetrics.AllBrokersProducerRequestRate"
+    },
+    {
+      "obj": "\"kafka.producer\":type=\"ProducerStats\",name=\"-FailedSendsPerSec\"",
+      "attr": [
+        "Count"
+      ],
+      "resultAlias": "sdkafka.producer.ProducerStats.FailedSendsPerSec"
+    },
+    {
+      "obj": "\"kafka.producer\":type=\"ProducerTopicMetrics\",name=\"-AllTopicsBytesPerSec\"",
+      "attr": [
+        "Count"
+      ],
+      "resultAlias": "sdkafka.producer.ProducerTopicMetrics.AllTopicsBytes"
+    },
+    {
+      "obj": "\"kafka.producer\":type=\"ProducerTopicMetrics\",name=\"-AllTopicsDroppedMessagesPerSec\"",
+      "attr": [
+        "Count"
+      ],
+      "resultAlias": "sdkafka.producer.ProducerTopicMetrics.AllTopicsDroppedMessages"
+    },
+    {
+      "obj": "\"kafka.producer\":type=\"ProducerTopicMetrics\",name=\"-AllTopicsMessagesPerSec\"",
+      "attr": [
+        "Count"
+      ],
+      "resultAlias": "sdkafka.producer.ProducerTopicMetrics.AllTopicsMessages"
+    }
+  ]
+}

--- a/jmxtrans/templates/tomcat-7.json.tmpl
+++ b/jmxtrans/templates/tomcat-7.json.tmpl
@@ -1,0 +1,44 @@
+{
+  "serverInfo": {
+    "port": "TOMCAT_JMX_PORT",
+    "host": "TOMCAT_JMX_HOST",
+    "numQueryThreads": 2
+  },
+  "queryInfos": [
+    {
+      "obj": "Catalina:type=ThreadPool,name=*",
+      "resultAlias": "tomcat.connectors",
+      "attr": [
+        "currentThreadCount",
+        "currentThreadsBusy",
+        ""
+      ]
+    },
+    {
+      "obj": "Catalina:type=Manager,context=*,host=*",
+      "resultAlias": "tomcat.manager",
+      "attr": [
+        "activeSessions"
+      ]
+    },
+    {
+      "obj": "Catalina:type=GlobalRequestProcessor,name=*",
+      "resultAlias": "tomcat.requestProcessor",
+      "attr": [
+        "bytesReceived",
+        "bytesSent",
+        "errorCount",
+        "processingTime",
+        "requestCount"
+      ]
+    },
+    {
+      "obj": "Catalina:type=DataSource,context=*,host=*,class=javax.sql.DataSource,name=*",
+      "resultAlias": "tomcat.data-source",
+      "attr": [
+        "numActive",
+        "numIdle"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The purpose of this PR is to create a framework to autogenerate the JMX JSON files.

There are four flavors of JSON files, and they differ only in small details. The four flavors are {stackdriver, google-cloud-monitoring} x {json-detect-instance,json-specify-instance}

The approach taken in this PR is to create ".tmpl" files in the "templates" directory, and a Python script to generate the four flavors of files from the templates.

**This Pull Request has three parts:**
1. The first commit is the Python program (`generate-json-files-from-templates.py`) and its helper library (`differ.py`). The reason for the 'differ' library is explained below.
2. The second commit is all the .tmpl files. The tmpl file has a pretty straightforward syntax. The purpose of `generate-json-files-from-templates.py` is to move the properties from the .tmpl file to the right place in the output.
3. The third commit is the result of running the generator on the .tmpl files. Though it looks like there are a lot of changes, these are primarily the result of formatting changes, missing files, and human error. *The differences are summarized in the file `differences.txt` (which exists for the benefit of the reviewer and might not be checked in after this PR is accepted).*

**Why differ.py**
It is labor-intensive for a human to look at the differences between 'old' and 'new' files to decide whether they're valid. To help with this, I wrote 'differ.py' which shows the meaningful (not whitespace-related) differences. Looking at `differences.txt`, we can readily see that the changes are simply:

1. Standardization of the text `INSTANCE_ID`. This is changed to `AWS_INSTANCE_ID` for the stackdriver items and `GCE_INSTANCE_ID `for the google-cloud-monitoring items.
  1. In some cases `AWS_INSTANCE_ID` appeared in a google-cloud-monitoring subdirectory, so this needed to be changed to `GCE_INSTANCE_ID`.
2. Missing files: `cassandra-06.json` was missing from {stackdriver, google-cloud-monitoring} x json-specify-instance.
3. Inconsistent specification of `CASSANDRA_HOST` and `CASSANDRA_PORT`. Some files used the above, and others used localhost/7199.
